### PR TITLE
feat: 全局快捷键+数据导出导入+去重 (Issues #8 #9 #10)

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -82,6 +82,13 @@ class ClipboardWatcher {
     // 检测代码语言
     const language = type === 'code' ? this._detectLanguage(trimmed) : null;
 
+    // 检查去重（可选功能，默认不启用）
+    const lastRecords = this.db.getRecords({ limit: 1 });
+    if (lastRecords.length > 0 && lastRecords[0].content === trimmed) {
+      this.log.info('内容重复，跳过记录');
+      return;
+    }
+
     // 异步生成 AI 摘要和嵌入向量
     this._generateAI(trimmed).then(aiResult => {
       // 保存到数据库

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,7 @@
  * 负责窗口管理、系统托盘、IPC 通信
  */
 
-const { app, BrowserWindow, Tray, Menu, ipcMain, clipboard, nativeImage, shell, dialog } = require('electron');
+const { app, BrowserWindow, Tray, Menu, ipcMain, clipboard, nativeImage, shell, dialog, globalShortcut } = require('electron');
 const path = require('path');
 const log = require('electron-log');
 
@@ -273,6 +273,72 @@ function setupIPC() {
   log.info('IPC 处理器已注册');
 }
 
+// 导出数据
+ipcMain.handle('export-data', async (event, { format = 'json' }) => {
+  try {
+    const records = db.getRecords({ limit: 10000 });
+    const { dialog } = require('electron');
+    
+    const result = await dialog.showSaveDialog(mainWindow, {
+      defaultPath: `clawboard-backup-${Date.now()}.${format}`,
+      filters: [
+        { name: 'JSON', extensions: ['json'] },
+        { name: 'CSV', extensions: ['csv'] },
+      ]
+    });
+    
+    if (result.canceled) return { success: false, message: '已取消' };
+    
+    const fs = require('fs');
+    let content;
+    
+    if (format === 'json') {
+      content = JSON.stringify(records, null, 2);
+    } else if (format === 'csv') {
+      const headers = 'id,type,content,summary,source,favorite,language,created_at\n';
+      const rows = records.map(r => 
+        `${r.id},"${r.type}","${(r.content || '').replace(/"/g, '""')}","${(r.summary || '').replace(/"/g, '""')}","${r.source}",${r.favorite || 0},"${r.language || ''}","${r.created_at}"`
+      ).join('\n');
+      content = headers + rows;
+    }
+    
+    fs.writeFileSync(result.filePath, content, 'utf-8');
+    return { success: true, message: `已导出 ${records.length} 条记录` };
+  } catch (err) {
+    log.error('export-data error:', err);
+    return { success: false, message: err.message };
+  }
+});
+
+// 导入数据
+ipcMain.handle('import-data', async (event, filePath) => {
+  try {
+    const fs = require('fs');
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const records = JSON.parse(content);
+    
+    let count = 0;
+    for (const record of records) {
+      if (record.content) {
+        db.addRecord({
+          type: record.type || 'text',
+          content: record.content,
+          summary: record.summary,
+          source: 'import',
+          favorite: record.favorite || 0,
+          language: record.language
+        });
+        count++;
+      }
+    }
+    
+    return { success: true, message: `已导入 ${count} 条记录` };
+  } catch (err) {
+    log.error('import-data error:', err);
+    return { success: false, message: err.message };
+  }
+});
+
 // 应用启动
 app.whenReady().then(async () => {
   log.info('应用准备就绪');
@@ -292,6 +358,9 @@ app.whenReady().then(async () => {
   // 注册 IPC
   setupIPC();
 
+  // 注册全局快捷键 Ctrl+Shift+V
+  registerGlobalShortcut();
+
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
@@ -306,6 +375,8 @@ app.on('before-quit', () => {
   if (clipboardWatcher) {
     clipboardWatcher.stop();
   }
+  // 注销全局快捷键
+  globalShortcut.unregisterAll();
 });
 
 app.on('window-all-closed', () => {
@@ -322,3 +393,23 @@ process.on('uncaughtException', (err) => {
 process.on('unhandledRejection', (reason) => {
   log.error('Unhandled Rejection:', reason);
 });
+
+// 注册全局快捷键
+function registerGlobalShortcut() {
+  const ret = globalShortcut.register('CommandOrControl+Shift+V', () => {
+    if (mainWindow) {
+      if (mainWindow.isVisible()) {
+        mainWindow.hide();
+      } else {
+        mainWindow.show();
+        mainWindow.focus();
+      }
+    }
+  });
+
+  if (!ret) {
+    log.warn('全局快捷键注册失败');
+  } else {
+    log.info('全局快捷键 Ctrl+Shift+V 已注册');
+  }
+}


### PR DESCRIPTION
## 改动说明

### 全局快捷键 (Issue #8)
- 注册 Ctrl+Shift+V 全局快捷键
- 快速调出/隐藏主窗口
- 应用退出时注销快捷键

### 数据导出导入 (Issue #9)
- 新增 export-data IPC 接口，支持 JSON/CSV 格式
- 新增 import-data IPC 接口，支持导入备份
- 使用系统文件对话框选择保存位置

### 历史记录去重 (Issue #10)
- 自动检测与上一条记录是否重复
- 重复内容跳过存储，减少冗余

## 改动文件
- src/main.js - 全局快捷键、导出导入 IPC
- src/clipboard.js - 去重逻辑

## 验收
- [x] Ctrl+Shift+V 可调出/隐藏窗口
- [x] 可导出为 JSON/CSV
- [x] 可导入备份文件
- [x] 连续重复内容自动跳过

---