### PR TITLE
feat: 窗口置顶 + 记录锁定 (Issues #20 #21)

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -82,9 +82,9 @@ class ClipboardWatcher {
     // 检测代码语言
     const language = type === 'code' ? this._detectLanguage(trimmed) : null;
 
-    // 检查去重（可选功能，默认不启用）
+    // 检查去重
     const lastRecords = this.db.getRecords({ limit: 1 });
-    if (lastRecords.length > 0 && lastRecords[0].content === trimmed) {
+    if (lastRecords.length > 0 && lastRecords[0].content === trimmed && !lastRecords[0].locked) {
       this.log.info('内容重复，跳过记录');
       return;
     }

--- a/src/database.js
+++ b/src/database.js
@@ -38,6 +38,7 @@ class Database {
         ai_summary TEXT,
         embedding BLOB,
         language TEXT,
+        locked INTEGER DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
@@ -98,16 +99,23 @@ class Database {
     const total = this.db.exec(`SELECT COUNT(*) FROM records`)[0]?.values[0][0] || 0;
     
     if (total > maxRecords) {
-      // 删除最早的未收藏记录
+      // 删除最早的未收藏且未锁定的记录
       const deleteCount = total - maxRecords;
       this.db.run(
         `DELETE FROM records WHERE id IN (
-          SELECT id FROM records WHERE favorite = 0 ORDER BY created_at ASC LIMIT ?
+          SELECT id FROM records WHERE favorite = 0 AND locked = 0 ORDER BY created_at ASC LIMIT ?
         )`,
         [deleteCount]
       );
       console.log(`自动清理了 ${deleteCount} 条旧记录`);
     }
+  }
+
+  // 切换锁定状态
+  toggleLock(id) {
+    this.db.run(`UPDATE records SET locked = NOT locked, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, [id]);
+    this._save();
+    return true;
   }
 
   // 获取记录

--- a/src/main.js
+++ b/src/main.js
@@ -128,6 +128,16 @@ function createTray() {
         shell.openPath(app.getPath('userData'));
       }
     },
+    {
+      label: '📌 窗口置顶',
+      type: 'checkbox',
+      checked: false,
+      click: (menuItem) => {
+        if (mainWindow) {
+          mainWindow.setAlwaysOnTop(menuItem.checked);
+        }
+      }
+    },
     { type: 'separator' },
     {
       label: '❌ 退出',
@@ -379,6 +389,30 @@ ipcMain.handle('delete-template', async (event, id) => {
     return db.deleteTemplate(id);
   } catch (err) {
     log.error('delete-template error:', err);
+    return false;
+  }
+});
+
+// 窗口置顶
+ipcMain.handle('set-always-on-top', async (event, flag) => {
+  try {
+    if (mainWindow) {
+      mainWindow.setAlwaysOnTop(flag);
+      return true;
+    }
+    return false;
+  } catch (err) {
+    log.error('set-always-on-top error:', err);
+    return false;
+  }
+});
+
+// 切换锁定状态
+ipcMain.handle('toggle-lock', async (event, id) => {
+  try {
+    return db.toggleLock(id);
+  } catch (err) {
+    log.error('toggle-lock error:', err);
     return false;
   }
 });


### PR DESCRIPTION
## 改动说明

### 窗口置顶 (Issue #20)
- 托盘菜单增加「窗口置顶」复选框
- 点击切换窗口始终在顶层显示
- 新增 IPC 接口 set-always-on-top

### 记录锁定 (Issue #21)
- 数据库新增 locked 字段
- 新增 toggleLock 方法和 IPC 接口
- 自动清理时跳过 locked=1 的记录
- 去重逻辑也跳过已锁定记录

## 改动文件
- src/main.js - 托盘菜单、IPC 接口
- src/database.js - locked 字段、锁定逻辑
- src/clipboard.js - 去重检查跳过锁定

## 验收
- [x] 托盘菜单可切换窗口置顶
- [x] 锁定记录不会被自动删除

---