### PR TITLE
feat: 文件拖拽+键盘快捷键 (Issues #23 #24)

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -55,6 +55,46 @@
         searchInput.focus();
         searchInput.select();
       }
+      // 键盘快捷操作
+      if (selectedRecord) {
+        if (e.key === 'Delete') {
+          e.preventDefault();
+          handleDeleteRecord();
+        }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleCopyRecord();
+        }
+        if (e.key === 'Escape') {
+          closeDetailPanel();
+        }
+      }
+    });
+
+    // 文件拖拽支持
+    document.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      document.body.classList.add('drag-over');
+    });
+
+    document.addEventListener('dragleave', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      document.body.classList.remove('drag-over');
+    });
+
+    document.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      document.body.classList.remove('drag-over');
+      
+      const files = e.dataTransfer.files;
+      if (files.length > 0) {
+        const filePaths = Array.from(files).map(f => f.path).join('\n');
+        await window.ClawBoard.copyToClipboard(filePaths);
+        showToast('✅ 文件路径已复制', 'success');
+      }
     });
 
     clearSearchBtn.addEventListener('click', () => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -7,6 +7,8 @@
 *{margin:0;padding:0;box-sizing:border-box}
 html,body{height:100%;overflow:hidden}
 body{background:var(--bg);color:var(--text);font-family:'Noto Sans SC',-apple-system,sans-serif;font-size:14px;line-height:1.6}
+body.drag-over{outline:3px dashed var(--accent);outline-offset:-3px}
+body.drag-over::after{content:'📁 释放文件自动复制路径';position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--accent);color:#fff;padding:1rem 2rem;border-radius:12px;font-size:1.2rem;pointer-events:none}
 button{font-family:inherit;cursor:pointer;border:none;outline:none}
 input{font-family:inherit;outline:none}
 ::-webkit-scrollbar{width:5px}


### PR DESCRIPTION
## 改动说明

### 文件拖拽 (Issue #23)
- 拖拽文件到窗口自动复制文件路径
- 拖拽时显示视觉提示
- 多文件支持（换行分隔）

### 键盘快捷键 (Issue #24)
- Delete 删除选中记录
- Enter 复制选中记录
- Esc 关闭详情面板

## 改动文件
- src/renderer/app.js - 拖拽处理、键盘事件
- src/renderer/styles.css - 拖拽视觉样式

## 验收
- [x] 拖拽文件自动复制路径
- [x] 快捷键可正常操作

---