### PR TITLE
feat: 剪贴板历史时间线视图 - 按时间分组展示

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -15,6 +15,8 @@
   // 多选模式状态
   let isMultiSelectMode = false;
   let selectedIds = new Set();
+  // 视图模式：'list' | 'timeline'
+  let currentViewMode = 'list';
 
   // ==================== DOM 元素 ====================
   const $ = (sel) => document.querySelector(sel);
@@ -169,6 +171,9 @@
     $('#btnBatchDelete').addEventListener('click', handleBatchDelete);
     $('#btnBatchExport').addEventListener('click', handleBatchExport);
 
+    // 视图切换
+    $('#btnViewToggle').addEventListener('click', toggleViewMode);
+
     // 详情面板点击外部关闭
     detailPanel.addEventListener('click', (e) => {
       if (e.target === detailPanel) {
@@ -262,6 +267,18 @@
 
   // ==================== 渲染 ====================
   function renderRecords() {
+    // 根据视图模式选择渲染方式
+    if (currentViewMode === 'timeline') {
+      renderTimelineView();
+    } else {
+      renderListView();
+    }
+  }
+
+  function renderListView() {
+    recordsList.style.display = '';
+    $('#timelineView').style.display = 'none';
+
     recordsList.innerHTML = '';
 
     if (records.length === 0) {
@@ -277,9 +294,113 @@
     });
   }
 
-  function createRecordCard(record, index) {
+  function renderTimelineView() {
+    recordsList.style.display = 'none';
+    const timelineView = $('#timelineView');
+    timelineView.style.display = '';
+
+    // 按时间分组
+    const groups = groupRecordsByTime(records);
+
+    timelineView.innerHTML = '';
+
+    if (records.length === 0) {
+      emptyState.classList.add('show');
+      return;
+    }
+
+    emptyState.classList.remove('show');
+
+    // 渲染每个分组
+    const groupOrder = ['today', 'yesterday', 'thisWeek', 'thisMonth', 'older'];
+    const groupLabels = {
+      today: '📅 今天',
+      yesterday: '📅 昨天',
+      thisWeek: '📆 本周',
+      thisMonth: '📆 本月',
+      older: '📆 更早',
+    };
+
+    groupOrder.forEach(groupKey => {
+      const groupRecords = groups[groupKey];
+      if (!groupRecords || groupRecords.length === 0) return;
+
+      const groupEl = document.createElement('div');
+      groupEl.className = 'timeline-group';
+
+      const header = document.createElement('div');
+      header.className = 'timeline-group-header';
+      header.innerHTML = `
+        <span class="timeline-group-title">${groupLabels[groupKey]}</span>
+        <span class="timeline-group-count">${groupRecords.length} 条</span>
+        <span class="timeline-group-toggle">▼</span>
+      `;
+      header.addEventListener('click', () => {
+        groupEl.classList.toggle('collapsed');
+        header.querySelector('.timeline-group-toggle').textContent =
+          groupEl.classList.contains('collapsed') ? '▶' : '▼';
+      });
+
+      const content = document.createElement('div');
+      content.className = 'timeline-group-content';
+
+      groupRecords.forEach((record, index) => {
+        const card = createRecordCard(record, index, true);
+        content.appendChild(card);
+      });
+
+      groupEl.appendChild(header);
+      groupEl.appendChild(content);
+      timelineView.appendChild(groupEl);
+    });
+  }
+
+  function groupRecordsByTime(records) {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const thisWeekStart = new Date(today);
+    thisWeekStart.setDate(thisWeekStart.getDate() - today.getDay());
+    const thisMonthStart = new Date(today.getFullYear(), today.getMonth(), 1);
+
+    const groups = {
+      today: [],
+      yesterday: [],
+      thisWeek: [],
+      thisMonth: [],
+      older: [],
+    };
+
+    records.forEach(record => {
+      const recordDate = new Date(record.created_at);
+      if (recordDate >= today) {
+        groups.today.push(record);
+      } else if (recordDate >= yesterday) {
+        groups.yesterday.push(record);
+      } else if (recordDate >= thisWeekStart) {
+        groups.thisWeek.push(record);
+      } else if (recordDate >= thisMonthStart) {
+        groups.thisMonth.push(record);
+      } else {
+        groups.older.push(record);
+      }
+    });
+
+    return groups;
+  }
+
+  function toggleViewMode() {
+    currentViewMode = currentViewMode === 'list' ? 'timeline' : 'list';
+    const btn = $('#btnViewToggle');
+    btn.textContent = currentViewMode === 'timeline' ? '📋' : '📅';
+    btn.classList.toggle('active', currentViewMode === 'timeline');
+    renderRecords();
+  }
+
+  function createRecordCard(record, index, isTimelineMode = false) {
     const card = document.createElement('div');
-    card.className = 'record-card' + (record.favorite ? ' favorite' : '');
+    card.className = 'record-card' + (record.favorite ? ' favorite' : '') + (isTimelineMode ? ' timeline-card' : '');
     card.dataset.id = record.id;
     card.style.animationDelay = `${index * 30}ms`;
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -26,6 +26,7 @@
       <button class="search-clear" id="clearSearch" title="清除搜索">×</button>
     </div>
     <div class="header-right">
+      <button class="icon-btn" id="btnViewToggle" title="切换视图">📋</button>
       <button class="icon-btn" id="btnMultiSelect" title="多选模式">☑️</button>
       <span class="stats-badge" id="statsBadge" title="总记录数">
         <span class="stats-icon">📋</span>
@@ -58,6 +59,11 @@
   <!-- 主内容 -->
   <main class="main">
     <div class="records-list" id="recordsList">
+      <!-- 动态填充 -->
+    </div>
+    
+    <!-- 时间线视图 -->
+    <div class="timeline-view" id="timelineView" style="display:none">
       <!-- 动态填充 -->
     </div>
     

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -151,6 +151,7 @@ input{font-family:inherit;outline:none}
 
 /* 多选批量操作 */
 .icon-btn.active{background:var(--accent-bg);color:var(--accent)}
+.icon-btn#btnViewToggle.active{background:var(--accent-bg);color:var(--accent)}
 .select-all-btn{display:none;margin-left:auto}
 .select-all-btn.show{display:block}
 .batch-bar{position:fixed;bottom:0;left:0;right:0;height:60px;padding:0 1.5rem;display:flex;align-items:center;gap:1rem;background:rgba(8,11,18,0.95);backdrop-filter:blur(20px);border-top:1px solid var(--border);z-index:50;transform:translateY(100%);transition:transform 0.3s ease}
@@ -169,3 +170,17 @@ input{font-family:inherit;outline:none}
 .record-checkbox.checked{border-color:var(--accent);background:var(--accent);color:#fff}
 .main{bottom:60px}
 .batch-bar.show~.main{bottom:120px}
+
+/* 时间线视图 */
+.timeline-view{padding:0}
+.timeline-group{margin-bottom:0.5rem;border:1px solid var(--border);border-radius:12px;background:var(--surface);overflow:hidden}
+.timeline-group-header{display:flex;align-items:center;padding:1rem 1.2rem;cursor:pointer;transition:all 0.2s;gap:0.8rem}
+.timeline-group-header:hover{background:rgba(255,255,255,0.03)}
+.timeline-group-title{font-weight:600;color:var(--text);flex:1}
+.timeline-group-count{font-size:0.8rem;color:var(--muted)}
+.timeline-group-toggle{font-size:0.75rem;color:var(--muted);transition:transform 0.2s}
+.timeline-group.collapsed .timeline-group-content{display:none}
+.timeline-group.collapsed .timeline-group-toggle{transform:rotate(-90deg)}
+.timeline-group-content{padding:0 0.8rem 0.8rem}
+.timeline-card{margin-bottom:0.5rem}
+.timeline-card:last-child{margin-bottom:0}


### PR DESCRIPTION
## 功能描述

关闭 #31

添加时间线视图，按时间自动分组展示剪贴板历史。

## 变更内容

- **视图切换** - 顶部工具栏新增「📋」按钮，点击切换列表/时间线视图
- **时间分组** - 自动将记录按时间分组：
  - 📅 今天
  - 📅 昨天
  - 📆 本周（不含今天和昨天）
  - 📆 本月（不含本周）
  - 📆 更早
- **分组折叠** - 点击分组标题可折叠/展开
- **记录计数** - 每个分组显示记录数量
- **类型筛选** - 时间线视图下仍支持类型筛选（文字/代码/图片等）
- **主题适配** - 时间线视图适配深色和浅色主题

## 竞品对标

- ✅ CopyQ 按时间分组显示
- ✅ Maccy 按日期分组

## 测试

1. 点击顶部「📋」按钮切换到时间线视图
2. 验证记录按时间正确分组
3. 点击分组标题测试折叠/展开
4. 切换类型筛选测试分组是否正确过滤
5. 切换深色/浅色主题验证样式适配
6. 再次点击按钮切换回列表视图