### PR TITLE
feat: 快捷键管理面板 - 自定义操作快捷键

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -36,6 +36,7 @@
   // ==================== 初始化 ====================
   async function init() {
     setupEventListeners();
+    initShortcutRecording();  // 初始化快捷键录制
     await loadRecords();
     await loadStats();
     setupIpcListeners();
@@ -132,6 +133,17 @@
     $('#btnSettings').addEventListener('click', () => {
       loadSettings();
       settingsOverlay.classList.add('show');
+    });
+
+    // 设置标签切换
+    $$('.settings-tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        $$('.settings-tab').forEach(t => t.classList.remove('active'));
+        $$('.settings-tab-content').forEach(c => c.classList.remove('show'));
+        tab.classList.add('active');
+        const tabId = 'settings' + tab.dataset.tab.charAt(0).toUpperCase() + tab.dataset.tab.slice(1);
+        $('#' + tabId).classList.add('show');
+      });
     });
 
     $('#btnCloseSettings').addEventListener('click', () => {
@@ -249,9 +261,22 @@
       $('#settingOllama').value = settings.ollamaHost || 'http://localhost:11434';
       $('#settingAiSummary').checked = settings.aiSummary !== false;
       $('#settingStartWithSystem').checked = settings.startWithSystem || false;
-      $('#settingShortcut').value = settings.globalShortcut || 'Ctrl+Shift+V';
-      // 应用主题
       applyTheme(settings.theme || 'dark');
+
+      // 加载快捷键设置
+      const shortcuts = settings.shortcuts || {};
+      $('#shortcutGlobal').value = shortcuts.global || 'Ctrl+Shift+V';
+      $('#shortcutGlobal').dataset.value = shortcuts.global || 'Ctrl+Shift+V';
+      $('#shortcutSearch').value = shortcuts.search || 'Ctrl+K';
+      $('#shortcutSearch').dataset.value = shortcuts.search || 'Ctrl+K';
+      $('#shortcutCopy').value = shortcuts.copy || 'Enter';
+      $('#shortcutCopy').dataset.value = shortcuts.copy || 'Enter';
+      $('#shortcutDelete').value = shortcuts.delete || 'Delete';
+      $('#shortcutDelete').dataset.value = shortcuts.delete || 'Delete';
+      $('#shortcutEscape').value = shortcuts.escape || 'Escape';
+      $('#shortcutEscape').dataset.value = shortcuts.escape || 'Escape';
+      $('#shortcutSelectAll').value = shortcuts.selectAll || 'Ctrl+A';
+      $('#shortcutSelectAll').dataset.value = shortcuts.selectAll || 'Ctrl+A';
     } catch (err) {
       console.error('加载设置失败:', err);
     }
@@ -787,14 +812,25 @@
       aiSummary: $('#settingAiSummary').checked,
       startWithSystem: $('#settingStartWithSystem').checked,
       theme: $('#settingTheme').value || 'dark',
-      globalShortcut: $('#settingShortcut').value || 'Ctrl+Shift+V',
+    };
+
+    // 收集所有快捷键设置
+    const shortcuts = {
+      global: $('#shortcutGlobal').dataset.value || $('#shortcutGlobal').value,
+      search: $('#shortcutSearch').dataset.value || $('#shortcutSearch').value,
+      copy: $('#shortcutCopy').dataset.value || $('#shortcutCopy').value,
+      delete: $('#shortcutDelete').dataset.value || $('#shortcutDelete').value,
+      escape: $('#shortcutEscape').dataset.value || $('#shortcutEscape').value,
+      selectAll: $('#shortcutSelectAll').dataset.value || $('#shortcutSelectAll').value,
     };
 
     try {
       // 先保存设置
       await window.ClawBoard.saveSettings(settings);
-      // 更新快捷键
-      await window.ClawBoard.updateShortcut(settings.globalShortcut);
+      // 保存快捷键设置
+      await window.ClawBoard.saveShortcuts(shortcuts);
+      // 更新全局快捷键
+      await window.ClawBoard.updateShortcut(shortcuts.global);
       applyTheme(settings.theme);
       settingsOverlay.classList.remove('show');
       showToast('✅ 设置已保存', 'success');
@@ -803,7 +839,98 @@
     }
   }
 
+  // 添加重置快捷键按钮事件监听
+  $('#btnResetShortcuts').addEventListener('click', resetShortcuts);
+
   // ==================== 工具函数 ====================
+  // 默认快捷键配置
+  const defaultShortcuts = {
+    global: 'Ctrl+Shift+V',
+    search: 'Ctrl+K',
+    copy: 'Enter',
+    delete: 'Delete',
+    escape: 'Escape',
+    selectAll: 'Ctrl+A',
+  };
+
+  let currentRecordingInput = null;
+
+  function initShortcutRecording() {
+    const shortcutInputs = $$('.shortcut-input');
+    shortcutInputs.forEach(input => {
+      input.addEventListener('click', () => startShortcutRecording(input));
+      input.addEventListener('keydown', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      });
+    });
+  }
+
+  function startShortcutRecording(input) {
+    // 如果正在录制另一个，取消
+    if (currentRecordingInput && currentRecordingInput !== input) {
+      currentRecordingInput.classList.remove('recording');
+      currentRecordingInput.value = currentRecordingInput.dataset.value || '';
+    }
+
+    currentRecordingInput = input;
+    input.classList.add('recording');
+    input.value = '按下快捷键...';
+    input.readOnly = false;
+    input.focus();
+
+    // 绑定一次性键盘事件
+    const handleKeyDown = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const keys = [];
+      if (e.ctrlKey) keys.push('Ctrl');
+      if (e.shiftKey) keys.push('Shift');
+      if (e.altKey) keys.push('Alt');
+      if (e.metaKey) keys.push('Meta');
+
+      const key = e.key;
+      if (key && !['Control', 'Shift', 'Alt', 'Meta'].includes(key)) {
+        keys.push(key.length === 1 ? key.toUpperCase() : key);
+      }
+
+      if (keys.length > 0) {
+        const shortcut = keys.join('+');
+        input.value = shortcut;
+        input.dataset.value = shortcut;
+      }
+
+      input.classList.remove('recording');
+      currentRecordingInput = null;
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+
+    document.addEventListener('keydown', handleKeyDown, { once: true });
+
+    // 点击其他位置取消录制
+    const handleClickOutside = (e) => {
+      if (!input.contains(e.target)) {
+        input.classList.remove('recording');
+        input.value = input.dataset.value || '';
+        currentRecordingInput = null;
+        document.removeEventListener('keydown', handleKeyDown);
+        document.removeEventListener('click', handleClickOutside);
+      }
+    };
+    setTimeout(() => document.addEventListener('click', handleClickOutside), 100);
+  }
+
+  function resetShortcuts() {
+    const shortcutInputs = $$('.shortcut-input');
+    shortcutInputs.forEach(input => {
+      const key = input.id.replace('shortcut', '').toLowerCase();
+      const defaultVal = defaultShortcuts[key] || '';
+      input.value = defaultVal;
+      input.dataset.value = defaultVal;
+    });
+    showToast('✅ 快捷键已重置', 'success');
+  }
   function formatTimeAgo(date) {
     const now = new Date();
     const diff = now - date;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -113,42 +113,77 @@
         <h2>⚙️ 设置</h2>
         <button class="detail-close" id="btnCloseSettings">×</button>
       </div>
+      <!-- 设置标签 -->
+      <div class="settings-tabs">
+        <button class="settings-tab active" data-tab="general">通用</button>
+        <button class="settings-tab" data-tab="shortcuts">快捷键</button>
+      </div>
       <div class="settings-body">
-        <div class="setting-item">
-          <label>🔢 最大历史记录数</label>
-          <input type="number" id="settingMaxRecords" min="100" max="10000" value="1000">
+        <!-- 通用设置 -->
+        <div class="settings-tab-content" id="settingsGeneral">
+          <div class="setting-item">
+            <label>🔢 最大历史记录数</label>
+            <input type="number" id="settingMaxRecords" min="100" max="10000" value="1000">
+          </div>
+          <div class="setting-item">
+            <label>🤖 Ollama 地址</label>
+            <input type="text" id="settingOllama" value="http://localhost:11434" placeholder="http://localhost:11434">
+          </div>
+          <div class="setting-item">
+            <label>
+              <input type="checkbox" id="settingAiSummary" checked>
+              自动生成 AI 摘要
+            </label>
+          </div>
+          <div class="setting-item">
+            <label>
+              <input type="checkbox" id="settingStartWithSystem">
+              开机自启动
+            </label>
+          </div>
+          <div class="setting-item">
+            <label>🎨 主题模式</label>
+            <select id="settingTheme">
+              <option value="dark">深色</option>
+              <option value="light">浅色</option>
+            </select>
+          </div>
+          <div class="setting-item">
+            <label>🗑️ 清空所有历史记录</label>
+            <button class="btn-danger" id="btnClearHistory">清空历史（保留收藏）</button>
+          </div>
         </div>
-        <div class="setting-item">
-          <label>🤖 Ollama 地址</label>
-          <input type="text" id="settingOllama" value="http://localhost:11434" placeholder="http://localhost:11434">
-        </div>
-        <div class="setting-item">
-          <label>
-            <input type="checkbox" id="settingAiSummary" checked>
-            自动生成 AI 摘要
-          </label>
-        </div>
-        <div class="setting-item">
-          <label>
-            <input type="checkbox" id="settingStartWithSystem">
-            开机自启动
-          </label>
-        </div>
-        <div class="setting-item">
-          <label>🎨 主题模式</label>
-          <select id="settingTheme">
-            <option value="dark">深色</option>
-            <option value="light">浅色</option>
-          </select>
-        </div>
-        <div class="setting-item">
-          <label>⌨️ 全局快捷键</label>
-          <input type="text" id="settingShortcut" value="Ctrl+Shift+V" placeholder="Ctrl+Shift+V">
-          <small style="color: var(--muted); display: block; margin-top: 4px;">示例: Ctrl+Shift+V, Alt+V, F1</small>
-        </div>
-        <div class="setting-item">
-          <label>🗑️ 清空所有历史记录</label>
-          <button class="btn-danger" id="btnClearHistory">清空历史（保留收藏）</button>
+        <!-- 快捷键设置 -->
+        <div class="settings-tab-content" id="settingsShortcuts" style="display:none">
+          <div class="shortcuts-list">
+            <div class="shortcut-item">
+              <span class="shortcut-label">全局调出窗口</span>
+              <input type="text" class="shortcut-input" id="shortcutGlobal" value="Ctrl+Shift+V" readonly placeholder="点击设置">
+            </div>
+            <div class="shortcut-item">
+              <span class="shortcut-label">聚焦搜索框</span>
+              <input type="text" class="shortcut-input" id="shortcutSearch" value="Ctrl+K" readonly placeholder="点击设置">
+            </div>
+            <div class="shortcut-item">
+              <span class="shortcut-label">复制选中记录</span>
+              <input type="text" class="shortcut-input" id="shortcutCopy" value="Enter" readonly placeholder="点击设置">
+            </div>
+            <div class="shortcut-item">
+              <span class="shortcut-label">删除选中记录</span>
+              <input type="text" class="shortcut-input" id="shortcutDelete" value="Delete" readonly placeholder="点击设置">
+            </div>
+            <div class="shortcut-item">
+              <span class="shortcut-label">退出多选/关闭面板</span>
+              <input type="text" class="shortcut-input" id="shortcutEscape" value="Escape" readonly placeholder="点击设置">
+            </div>
+            <div class="shortcut-item">
+              <span class="shortcut-label">全选（多选模式）</span>
+              <input type="text" class="shortcut-input" id="shortcutSelectAll" value="Ctrl+A" readonly placeholder="点击设置">
+            </div>
+          </div>
+          <div class="setting-item" style="margin-top:1rem">
+            <button class="btn-secondary" id="btnResetShortcuts">重置为默认</button>
+          </div>
         </div>
       </div>
       <div class="settings-footer">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -184,3 +184,21 @@ input{font-family:inherit;outline:none}
 .timeline-group-content{padding:0 0.8rem 0.8rem}
 .timeline-card{margin-bottom:0.5rem}
 .timeline-card:last-child{margin-bottom:0}
+
+/* 快捷键管理 */
+.settings-tabs{display:flex;padding:0 1.5rem;gap:0.5rem;border-bottom:1px solid var(--border)}
+.settings-tab{padding:0.6rem 1rem;border:none;background:transparent;color:var(--muted);font-size:0.9rem;border-bottom:2px solid transparent;transition:all 0.2s;margin-bottom:-1px}
+.settings-tab:hover{color:var(--text)}
+.settings-tab.active{color:var(--accent);border-bottom-color:var(--accent)}
+.settings-tab-content{display:none}
+.settings-tab-content.show{display:block}
+.shortcuts-list{display:flex;flex-direction:column;gap:0.8rem}
+.shortcut-item{display:flex;align-items:center;justify-content:space-between;padding:0.6rem 0.8rem;background:var(--surface);border:1px solid var(--border);border-radius:8px}
+.shortcut-label{font-size:0.9rem;color:var(--text)}
+.shortcut-input{width:140px;height:32px;padding:0 0.8rem;border:1px solid var(--border);border-radius:6px;background:var(--surface2);color:var(--text);font-size:0.85rem;text-align:center;cursor:pointer;transition:all 0.2s}
+.shortcut-input:hover{border-color:var(--accent)}
+.shortcut-input:focus{border-color:var(--accent);outline:none;background:var(--accent-bg)}
+.shortcut-input.recording{border-color:var(--accent);background:var(--accent-bg);animation:pulse 1s infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:0.7}}
+.btn-secondary{padding:0.5rem 1rem;border-radius:8px;background:var(--surface);color:var(--text);font-size:0.9rem;transition:all 0.2s;border:1px solid var(--border)}
+.btn-secondary:hover{background:var(--surface2);border-color:var(--accent)}


### PR DESCRIPTION
## 功能描述

关闭 #33

在设置中添加快捷键管理面板，用户可以自定义各种操作的快捷键。

## 变更内容

- **设置面板重构** - 新增「通用」和「快捷键」两个标签页
- **快捷键列表** - 显示所有可自定义的快捷键：
  - 全局调出窗口 (Ctrl+Shift+V)
  - 聚焦搜索框 (Ctrl+K)
  - 复制选中记录 (Enter)
  - 删除选中记录 (Delete)
  - 退出多选/关闭面板 (Escape)
  - 全选 Ctrl+A)
- **快捷键录制** - 点击输入框进入录制模式，按下组合键即可设置
- **重置功能** - 一键恢复所有默认快捷键
- **主题适配** - 快捷键管理 UI 适配深色和浅色主题

## 竞品对标

- ✅ CopyQ 丰富的快捷键自定义
- ✅ Maccy 基础快捷键设置
- ✅ Ditto 快捷键绑定

## 测试

1. 打开设置面板，点击「快捷键」标签
2. 点击任意快捷键输入框
3. 按下新的组合键，验证快捷键设置成功
4. 点击「重置为默认」按钮
5. 切换深色/浅色主题验证样式适配