### PR TITLE
feat: 剪贴板历史统计与分析面板

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -397,6 +397,92 @@ class Database {
     return { total, text, image, file, code, favorite };
   }
 
+  // 获取详细统计
+  getDetailedStats() {
+    const basic = this.getStats();
+
+    // 今日记录数
+    const todayStart = new Date();
+    todayStart.setHours(0, 0, 0, 0);
+    const todayCount = this.db.exec(`SELECT COUNT(*) FROM records WHERE created_at >= ?`, [todayStart.toISOString()])[0]?.values[0][0] || 0;
+
+    // 本周记录数
+    const weekStart = new Date();
+    weekStart.setDate(weekStart.getDate() - weekStart.getDay());
+    weekStart.setHours(0, 0, 0, 0);
+    const weekCount = this.db.exec(`SELECT COUNT(*) FROM records WHERE created_at >= ?`, [weekStart.toISOString()])[0]?.values[0][0] || 0;
+
+    // 本月记录数
+    const monthStart = new Date();
+    monthStart.setDate(1);
+    monthStart.setHours(0, 0, 0, 0);
+    const monthCount = this.db.exec(`SELECT COUNT(*) FROM records WHERE created_at >= ?`, [monthStart.toISOString()])[0]?.values[0][0] || 0;
+
+    // 平均每日记录数
+    const firstRecord = this.db.exec(`SELECT MIN(created_at) FROM records`)[0]?.values[0][0];
+    let avgPerDay = 0;
+    if (firstRecord) {
+      const days = Math.max(1, Math.ceil((Date.now() - new Date(firstRecord).getTime()) / (1000 * 60 * 60 * 24)));
+      avgPerDay = Math.round((basic.total / days) * 10) / 10;
+    }
+
+    // 最活跃时段（按小时统计）
+    const hourlyStats = this.db.exec(`
+      SELECT strftime('%H', created_at) as hour, COUNT(*) as count
+      FROM records
+      GROUP BY hour
+      ORDER BY count DESC
+      LIMIT 3
+    `);
+    const peakHours = hourlyStats.length > 0
+      ? hourlyStats[0].values.map(([h, c]) => ({ hour: parseInt(h), count: c }))
+      : [];
+
+    // 类型占比
+    const typePercent = {};
+    if (basic.total > 0) {
+      typePercent.text = Math.round((basic.text / basic.total) * 100);
+      typePercent.image = Math.round((basic.image / basic.total) * 100);
+      typePercent.file = Math.round((basic.file / basic.total) * 100);
+      typePercent.code = Math.round((basic.code / basic.total) * 100);
+    }
+
+    // 最近7天趋势
+    const trend = [];
+    for (let i = 6; i >= 0; i--) {
+      const d = new Date();
+      d.setDate(d.getDate() - i);
+      d.setHours(0, 0, 0, 0);
+      const nextD = new Date(d);
+      nextD.setDate(nextD.getDate() + 1);
+      const count = this.db.exec(
+        `SELECT COUNT(*) FROM records WHERE created_at >= ? AND created_at < ?`,
+        [d.toISOString(), nextD.toISOString()]
+      )[0]?.values[0][0] || 0;
+      trend.push({
+        date: d.toISOString().slice(0, 10),
+        label: `${d.getMonth() + 1}/${d.getDate()}`,
+        count,
+      });
+    }
+
+    // 加密记录数
+    const encrypted = this.db.exec(`SELECT COUNT(*) FROM records WHERE encrypted = 1`)[0]?.values[0][0] || 0;
+
+    return {
+      ...basic,
+      today: todayCount,
+      week: weekCount,
+      month: monthCount,
+      avgPerDay,
+      peakHours,
+      typePercent,
+      trend,
+      encrypted,
+      firstRecordDate: firstRecord,
+    };
+  }
+
   // 获取设置
   getSettings() {
     const result = this.db.exec(`SELECT key, value FROM settings`);

--- a/src/main.js
+++ b/src/main.js
@@ -233,6 +233,16 @@ function setupIPC() {
     }
   });
 
+  // 获取详细统计
+  ipcMain.handle('get-detailed-stats', async () => {
+    try {
+      return db.getDetailedStats();
+    } catch (err) {
+      log.error('get-detailed-stats error:', err);
+      return null;
+    }
+  });
+
   // AI 摘要（占位）
   ipcMain.handle('ai-summary', async (event, text) => {
     try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   clearHistory: () => ipcRenderer.invoke('clear-history'),
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
   getStats: () => ipcRenderer.invoke('get-stats'),
+  getDetailedStats: () => ipcRenderer.invoke('get-detailed-stats'),
   
   // 搜索相关
   search: (query) => ipcRenderer.invoke('search', query),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -193,6 +193,21 @@
       $('#encryptionOverlay').classList.add('show');
       updateEncryptionUI();
     });
+
+    // 统计面板
+    $('#btnStats').addEventListener('click', async () => {
+      $('#statsOverlay').classList.add('show');
+      await loadDetailedStats();
+    });
+    $('#btnCloseStats').addEventListener('click', () => {
+      $('#statsOverlay').classList.remove('show');
+    });
+    $('#statsOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#statsOverlay')) {
+        $('#statsOverlay').classList.remove('show');
+      }
+    });
+
     $('#btnCloseEncryption').addEventListener('click', () => {
       $('#encryptionOverlay').classList.remove('show');
     });
@@ -285,6 +300,138 @@
       totalCount.textContent = stats.total;
     } catch (err) {
       console.error('加载统计失败:', err);
+    }
+  }
+
+  async function loadDetailedStats() {
+    const loading = $('#statsLoading');
+    const content = $('#statsContent');
+    loading.style.display = 'flex';
+
+    try {
+      const stats = await window.ClawBoard.getDetailedStats();
+      loading.style.display = 'none';
+
+      if (!stats) {
+        content.innerHTML = '<p style="color:var(--muted);text-align:center;padding:2rem">加载失败</p>';
+        return;
+      }
+
+      // 类型颜色
+      const typeColors = {
+        text: '#3b82f6',
+        code: '#a855f7',
+        file: '#22c55e',
+        image: '#f97316',
+      };
+
+      // 渲染统计面板
+      let html = `
+        <div class="stats-grid">
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.total}</div>
+            <div class="stats-card-label">总记录数</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.today}</div>
+            <div class="stats-card-label">今日新增</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.week}</div>
+            <div class="stats-card-label">本周新增</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.avgPerDay}</div>
+            <div class="stats-card-label">日均记录</div>
+          </div>
+        </div>
+
+        <div class="stats-section">
+          <div class="stats-section-title">📈 近7天趋势</div>
+          <div class="stats-trend">
+      `;
+
+      const maxTrend = Math.max(...stats.trend.map(t => t.count), 1);
+      stats.trend.forEach(day => {
+        const height = Math.max(4, Math.round((day.count / maxTrend) * 70));
+        html += `
+          <div class="stats-trend-bar" style="height:${height}px">
+            <span class="bar-label">${day.label}</span>
+          </div>
+        `;
+      });
+
+      html += `
+          </div>
+        </div>
+
+        <div class="stats-section">
+          <div class="stats-section-title">📂 类型分布</div>
+      `;
+
+      const typeLabels = { text: '文字', code: '代码', file: '文件', image: '图片' };
+      for (const [type, pct] of Object.entries(stats.typePercent)) {
+        html += `
+          <div class="stats-type-row">
+            <span class="stats-type-label">${typeLabels[type] || type}</span>
+            <div class="stats-type-bar">
+              <div class="stats-type-bar-fill" style="width:${pct}%;background:${typeColors[type] || 'var(--accent)'}"></div>
+            </div>
+            <span class="stats-type-pct">${pct}%</span>
+          </div>
+        `;
+      }
+
+      html += `
+          </div>
+      `;
+
+      // 最活跃时段
+      if (stats.peakHours && stats.peakHours.length > 0) {
+        html += `
+          <div class="stats-section">
+            <div class="stats-section-title">⏰ 最活跃时段</div>
+            <div class="stats-peak-hours">
+        `;
+        stats.peakHours.forEach(h => {
+          const label = `${String(h.hour).padStart(2, '0')}:00`;
+          html += `<span class="stats-peak-hour">${label} (${h.count}条)</span>`;
+        });
+        html += `
+            </div>
+          </div>
+        `;
+      }
+
+      // 其他统计
+      html += `
+        <div class="stats-section">
+          <div class="stats-section-title">📋 其他统计</div>
+        </div>
+        <div class="stats-grid">
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.favorite}</div>
+            <div class="stats-card-label">⭐ 收藏数</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.encrypted}</div>
+            <div class="stats-card-label">🔒 加密数</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.month}</div>
+            <div class="stats-card-label">本月记录</div>
+          </div>
+          <div class="stats-card">
+            <div class="stats-card-value">${stats.code}</div>
+            <div class="stats-card-label">💻 代码数</div>
+          </div>
+        </div>
+      `;
+
+      content.innerHTML = html;
+    } catch (err) {
+      loading.style.display = 'none';
+      content.innerHTML = '<p style="color:var(--muted);text-align:center;padding:2rem">加载失败: ' + err.message + '</p>';
     }
   }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -27,6 +27,7 @@
     </div>
     <div class="header-right">
       <button class="icon-btn" id="btnViewToggle" title="切换视图">📋</button>
+      <button class="icon-btn" id="btnStats" title="统计">📊</button>
       <button class="icon-btn" id="btnEncryption" title="加密">🔒</button>
       <button class="icon-btn" id="btnMultiSelect" title="多选模式">☑️</button>
       <span class="stats-badge" id="statsBadge" title="总记录数">
@@ -116,6 +117,22 @@
     </div>
     <div class="detail-footer" id="detailFooter">
       <!-- AI 摘要等 -->
+    </div>
+  </div>
+
+  <!-- 统计面板 -->
+  <div class="settings-overlay" id="statsOverlay">
+    <div class="settings-panel stats-panel">
+      <div class="settings-header">
+        <h2>📊 使用统计</h2>
+        <button class="detail-close" id="btnCloseStats">×</button>
+      </div>
+      <div class="settings-body" id="statsContent">
+        <div class="stats-loading" id="statsLoading">
+          <div class="spinner"></div>
+          <span>加载中...</span>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -215,6 +215,25 @@ input{font-family:inherit;outline:none}
 .record-card.encrypted-card::before{background:#eab308}
 .encrypted-badge{font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:3px;background:rgba(234,179,8,0.15);color:#facc15;margin-left:0.3rem}
 
+/* 统计面板 */
+.stats-panel{width:520px;max-height:80vh}
+.stats-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:0.8rem;margin-bottom:1.5rem}
+.stats-card{padding:1rem;background:var(--surface);border:1px solid var(--border);border-radius:10px;text-align:center}
+.stats-card-value{font-size:1.8rem;font-weight:700;color:var(--accent)}
+.stats-card-label{font-size:0.8rem;color:var(--muted);margin-top:0.3rem}
+.stats-section{margin-bottom:1.5rem}
+.stats-section-title{font-size:0.9rem;font-weight:600;color:var(--text);margin-bottom:0.8rem;padding-bottom:0.5rem;border-bottom:1px solid var(--border)}
+.stats-trend{display:flex;gap:0.4rem;align-items:flex-end;height:80px}
+.stats-trend-bar{flex:1;background:var(--accent-bg);border-radius:4px 4px 0 0;min-height:4px;transition:height 0.3s;display:flex;align-items:flex-end;justify-content:center}
+.stats-trend-bar .bar-label{font-size:0.6rem;color:var(--muted);padding-bottom:2px}
+.stats-type-row{display:flex;align-items:center;gap:0.8rem;padding:0.5rem 0}
+.stats-type-bar{flex:1;height:8px;background:var(--surface);border-radius:4px;overflow:hidden}
+.stats-type-bar-fill{height:100%;border-radius:4px;transition:width 0.5s}
+.stats-type-label{font-size:0.8rem;color:var(--muted);min-width:50px;text-align:right}
+.stats-type-pct{font-size:0.8rem;font-weight:600;min-width:35px;text-align:right}
+.stats-peak-hours{display:flex;gap:0.8rem;flex-wrap:wrap}
+.stats-peak-hour{padding:0.4rem 0.8rem;background:var(--accent-bg);border-radius:8px;font-size:0.85rem;color:var(--accent)}
+
 /* v0.17.0: OCR 功能样式 */
 .ocr-section{margin-top:1rem;padding:1rem;background:var(--surface2);border:1px solid var(--border);border-radius:10px}
 .ocr-header{display:flex;align-items:center;gap:0.5rem;margin-bottom:0.8rem;font-size:0.9rem}


### PR DESCRIPTION
## 功能描述

关闭 #40

添加详细的剪贴板使用统计与分析面板。

## 变更内容

- **详细统计 API** - getDetailedStats() 返回丰富的统计数据
- **核心指标** - 总记录数、今日/本周/本月新增、日均记录数
- **7天趋势** - 近7天每日记录数柱状图数据
- **类型分布** - 文字/代码/文件/图片占比百分比条形图
- **活跃时段** - 记录最频繁的小时段 Top 3
- **其他统计** - 收藏数、加密数、本月记录数、代码数
- **统计面板 UI** - 顶部📊按钮打开网格化统计面板
- **主题适配** - 统计面板样式适配深色/浅色主题

## 竞品对标

- ✅ CopyQ 统计功能
- ✅ Maccy 使用分析

## 测试

1. 点击顶部📊按钮打开统计面板
2. 验证各项统计数据正确显示
3. 验证7天趋势图表渲染
4. 验证类型分布条形图
5. 切换深色/浅色主题验证样式适配