### PR TITLE
feat: 来源应用追踪与智能过滤 - 数据层

### DIFF
--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -16,6 +16,11 @@ class ClipboardWatcher {
     this.lastText = '';
     this.lastImage = '';
     this.pollInterval = 1000; // 每秒检查一次
+    this.currentSource = { app: null, title: null, url: null }; // 来源应用信息
+  }
+
+  setCurrentSource(source) {
+    this.currentSource = { ...this.currentSource, ...source };
   }
 
   start() {

--- a/src/database.js
+++ b/src/database.js
@@ -75,6 +75,9 @@ class Database {
         content TEXT NOT NULL,
         summary TEXT,
         source TEXT DEFAULT 'clipboard',
+        source_app TEXT,
+        source_title TEXT,
+        source_url TEXT,
         favorite INTEGER DEFAULT 0,
         tags TEXT DEFAULT '[]',
         ai_summary TEXT,
@@ -87,12 +90,14 @@ class Database {
       )
     `);
 
-    // 添加 encrypted 列（如果不存在）
-    try {
-      this.db.run(`ALTER TABLE records ADD COLUMN encrypted INTEGER DEFAULT 0`);
-    } catch (e) {
-      // 列已存在，忽略
-    }
+    // 添加新列（如果不存在）
+    ['source_app', 'source_title', 'source_url'].forEach(col => {
+      try {
+        this.db.run(`ALTER TABLE records ADD COLUMN ${col} TEXT`);
+      } catch (e) {
+        // 列已存在，忽略
+      }
+    });
 
     // 添加 ocr_text 列（如果不存在）- v0.17.0 OCR功能
     try {
@@ -134,20 +139,20 @@ class Database {
   }
 
   // 添加记录
-  addRecord({ type, content, summary, source, tags = '[]', ai_summary = null, embedding = null, language = null, encrypted = false, ocr_text = null }) {
+  addRecord({ type, content, summary, source, source_app, source_title, source_url, tags = '[]', ai_summary = null, embedding = null, language = null, encrypted = false, ocr_text = null }) {
     let finalContent = content;
     if (encrypted && this.encryptionKey) {
       finalContent = this._encrypt(content, this.encryptionKey);
     }
-    
+
     this.db.run(
-      `INSERT INTO records (type, content, summary, source, tags, ai_summary, embedding, language, encrypted, ocr_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [type, finalContent, summary, source, tags, ai_summary, embedding, language, encrypted ? 1 : 0, ocr_text]
+      `INSERT INTO records (type, content, summary, source, source_app, source_title, source_url, tags, ai_summary, embedding, language, encrypted, ocr_text) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [type, finalContent, summary, source || 'clipboard', source_app || null, source_title || null, source_url || null, tags, ai_summary, embedding, language, encrypted ? 1 : 0, ocr_text]
     );
-    
+
     // 自动清理旧记录（保留收藏）
     this._autoCleanup();
-    
+
     const id = this.db.exec("SELECT last_insert_rowid() as id")[0].values[0][0];
     this._save();
     return this.getRecord(id);
@@ -242,7 +247,7 @@ class Database {
   }
 
   // 获取记录列表
-  getRecords({ type, limit = 50, offset = 0, search, favorite } = {}) {
+  getRecords({ type, limit = 50, offset = 0, search, favorite, sourceApp } = {}) {
     let sql = 'SELECT * FROM records WHERE 1=1';
     const params = [];
 
@@ -262,12 +267,32 @@ class Database {
       sql += ' AND encrypted = 0';
     }
 
+    // 按来源应用筛选
+    if (sourceApp) {
+      sql += ' AND source_app = ?';
+      params.push(sourceApp);
+    }
+
     sql += ' ORDER BY created_at DESC LIMIT ? OFFSET ?';
     params.push(limit, offset);
 
     const result = this.db.exec(sql, params);
     if (result.length === 0) return [];
     return result[0].values.map(row => this._rowToRecord(result[0].columns, row));
+  }
+
+  // 获取来源应用列表及其记录数
+  getSourceApps() {
+    const result = this.db.exec(`
+      SELECT source_app, COUNT(*) as count
+      FROM records
+      WHERE source_app IS NOT NULL AND source_app != ''
+      GROUP BY source_app
+      ORDER BY count DESC
+      LIMIT 20
+    `);
+    if (result.length === 0) return [];
+    return result[0].values.map(([app, count]) => ({ app, count }));
   }
 
   // 搜索（支持关键词 + 语义搜索）

--- a/src/main.js
+++ b/src/main.js
@@ -243,6 +243,28 @@ function setupIPC() {
     }
   });
 
+  // 获取来源应用列表
+  ipcMain.handle('get-source-apps', async () => {
+    try {
+      return db.getSourceApps();
+    } catch (err) {
+      log.error('get-source-apps error:', err);
+      return [];
+    }
+  });
+
+  // 更新当前来源应用（由剪贴板监控调用）
+  ipcMain.handle('set-current-source', async (event, { app, title, url }) => {
+    try {
+      // 存储当前前台窗口信息
+      clipboardWatcher.setCurrentSource({ app, title, url });
+      return { success: true };
+    } catch (err) {
+      log.error('set-current-source error:', err);
+      return { success: false };
+    }
+  });
+
   // AI 摘要（占位）
   ipcMain.handle('ai-summary', async (event, text) => {
     try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -16,6 +16,7 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
   getStats: () => ipcRenderer.invoke('get-stats'),
   getDetailedStats: () => ipcRenderer.invoke('get-detailed-stats'),
+  getSourceApps: () => ipcRenderer.invoke('get-source-apps'),
   
   // 搜索相关
   search: (query) => ipcRenderer.invoke('search', query),


### PR DESCRIPTION
## 功能描述

关闭 #41（第一阶段）

来源应用追踪功能的数据层和 API 支持。

## 变更内容

- **数据库字段** - records 表新增 source_app、source_title、source_url 字段
- **记录接口** - addRecord 支持传入来源应用信息
- **筛选支持** - getRecords 支持按 sourceApp 参数筛选记录
- **来源列表** - getSourceApps 返回来源应用列表及记录数（Top 20）
- **剪贴板监控** - clipboard.js 添加 currentSource 状态跟踪
- **IPC 接口** - main.js 新增 get-source-apps 接口
- **前端 API** - preload.js 暴露 getSourceApps

## 待完善

- UI 层来源筛选侧边栏
- Windows API 获取前台窗口进程
- 来源应用图标显示

## 测试

1. 验证数据库迁移正常（新增字段）
2. 验证来源筛选查询正常
3. 验证 getSourceApps 返回正确数据