### PR TITLE
feat: v0.24.0 - 拖拽排序与分组管理

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -115,6 +115,31 @@ class Database {
       }
     });
 
+    // 添加分组和排序相关列（如果不存在）- v0.24.0 分组管理
+    try {
+      this.db.run(`ALTER TABLE records ADD COLUMN sort_order INTEGER DEFAULT 0`);
+    } catch (e) {
+      // 列已存在，忽略
+    }
+    try {
+      this.db.run(`ALTER TABLE records ADD COLUMN group_id INTEGER`);
+    } catch (e) {
+      // 列已存在，忽略
+    }
+
+    // 创建分组表
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS groups (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        color TEXT DEFAULT '#3b82f6',
+        icon TEXT DEFAULT '📁',
+        collapsed INTEGER DEFAULT 0,
+        sort_order INTEGER DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_type ON records(type)`);
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_favorite ON records(favorite)`);
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_created ON records(created_at DESC)`);
@@ -836,6 +861,158 @@ class Database {
       this._save();
       this.db.close();
     }
+  }
+
+  // ==================== 分组管理 ====================
+  // 获取所有分组
+  getAllGroups() {
+    const result = this.db.exec(`SELECT * FROM groups ORDER BY sort_order ASC, created_at DESC`);
+    if (result.length === 0) return [];
+    return result[0].values.map(row => {
+      const group = {};
+      result[0].columns.forEach((col, i) => group[col] = row[i]);
+      return group;
+    });
+  }
+
+  // 创建分组
+  createGroup(name, color = '#3b82f6', icon = '📁') {
+    // 获取最大排序值
+    const maxOrder = this.db.exec(`SELECT MAX(sort_order) FROM groups`)[0]?.values[0][0] || 0;
+    
+    this.db.run(
+      `INSERT INTO groups (name, color, icon, sort_order) VALUES (?, ?, ?, ?)`,
+      [name, color, icon, maxOrder + 1]
+    );
+    const id = this.db.exec(`SELECT last_insert_rowid() as id`)[0].values[0][0];
+    this._save();
+    return this.getGroup(id);
+  }
+
+  // 获取单个分组
+  getGroup(id) {
+    const result = this.db.exec(`SELECT * FROM groups WHERE id = ?`, [id]);
+    if (result.length === 0 || result[0].values.length === 0) return null;
+    const group = {};
+    result[0].columns.forEach((col, i) => group[col] = result[0].values[0][i]);
+    return group;
+  }
+
+  // 更新分组
+  updateGroup(id, { name, color, icon, collapsed, sort_order }) {
+    const updates = [];
+    const params = [];
+    
+    if (name !== undefined) { updates.push('name = ?'); params.push(name); }
+    if (color !== undefined) { updates.push('color = ?'); params.push(color); }
+    if (icon !== undefined) { updates.push('icon = ?'); params.push(icon); }
+    if (collapsed !== undefined) { updates.push('collapsed = ?'); params.push(collapsed ? 1 : 0); }
+    if (sort_order !== undefined) { updates.push('sort_order = ?'); params.push(sort_order); }
+    
+    if (updates.length === 0) return this.getGroup(id);
+    
+    params.push(id);
+    this.db.run(`UPDATE groups SET ${updates.join(', ')} WHERE id = ?`, params);
+    this._save();
+    return this.getGroup(id);
+  }
+
+  // 删除分组（将记录移到未分组）
+  deleteGroup(id) {
+    // 先将分组中的记录移到未分组
+    this.db.run(`UPDATE records SET group_id = NULL WHERE group_id = ?`, [id]);
+    this.db.run(`DELETE FROM groups WHERE id = ?`, [id]);
+    this._save();
+    return true;
+  }
+
+  // 切换分组折叠状态
+  toggleGroupCollapsed(id) {
+    const group = this.getGroup(id);
+    if (!group) return false;
+    this.db.run(`UPDATE groups SET collapsed = NOT collapsed WHERE id = ?`, [id]);
+    this._save();
+    return true;
+  }
+
+  // 移动记录到分组
+  moveRecordToGroup(recordId, groupId) {
+    this.db.run(
+      `UPDATE records SET group_id = ? WHERE id = ?`,
+      [groupId, recordId]
+    );
+    this._save();
+    return true;
+  }
+
+  // 获取分组中的记录
+  getRecords({ type, limit = 50, offset = 0, search, favorite, sourceApp, tag, groupId } = {}) {
+    let sql = 'SELECT * FROM records WHERE 1=1';
+    const params = [];
+
+    if (type) {
+      sql += ' AND type = ?';
+      params.push(type);
+    }
+
+    if (favorite) {
+      sql += ' AND favorite = 1';
+    }
+
+    if (search) {
+      sql += ' AND (content LIKE ? OR summary LIKE ? OR ocr_text LIKE ?)';
+      params.push(`%${search}%`, `%${search}%`, `%${search}%`);
+      sql += ' AND encrypted = 0';
+    }
+
+    if (sourceApp) {
+      sql += ' AND source_app = ?';
+      params.push(sourceApp);
+    }
+
+    if (tag) {
+      sql += ' AND tags LIKE ?';
+      params.push(`%"${tag}"%`);
+    }
+
+    if (groupId !== undefined) {
+      if (groupId === null) {
+        sql += ' AND group_id IS NULL';
+      } else {
+        sql += ' AND group_id = ?';
+        params.push(groupId);
+      }
+    }
+
+    sql += ' ORDER BY sort_order ASC, created_at DESC LIMIT ? OFFSET ?';
+    params.push(limit, offset);
+
+    const result = this.db.exec(sql, params);
+    if (result.length === 0) return [];
+    return result[0].values.map(row => this._rowToRecord(result[0].columns, row));
+  }
+
+  // 更新记录排序
+  updateRecordSortOrder(recordId, newOrder, newGroupId = null) {
+    this.db.run(
+      `UPDATE records SET sort_order = ?, group_id = ? WHERE id = ?`,
+      [newOrder, newGroupId, recordId]
+    );
+    this._save();
+    return true;
+  }
+
+  // 批量更新排序
+  batchUpdateSortOrder(updates) {
+    // updates: [{ id, sort_order, group_id }]
+    for (const update of updates) {
+      this.db.run(
+        `UPDATE records SET sort_order = ?, group_id = ? WHERE id = ?`,
+        [update.sort_order, update.group_id, update.id]
+      );
+    }
+    this._save();
+    return true;
   }
 
   // 辅助：将列和值转为对象

--- a/src/main.js
+++ b/src/main.js
@@ -606,6 +606,87 @@ ipcMain.handle('save-record', async (event, record) => {
   }
 });
 
+// ==================== 分组管理 ====================
+// 获取所有分组
+ipcMain.handle('get-all-groups', async () => {
+  try {
+    return db.getAllGroups();
+  } catch (err) {
+    log.error('get-all-groups error:', err);
+    return [];
+  }
+});
+
+// 创建分组
+ipcMain.handle('create-group', async (event, { name, color, icon }) => {
+  try {
+    return db.createGroup(name, color, icon);
+  } catch (err) {
+    log.error('create-group error:', err);
+    return null;
+  }
+});
+
+// 更新分组
+ipcMain.handle('update-group', async (event, { id, ...updates }) => {
+  try {
+    return db.updateGroup(id, updates);
+  } catch (err) {
+    log.error('update-group error:', err);
+    return null;
+  }
+});
+
+// 删除分组
+ipcMain.handle('delete-group', async (event, id) => {
+  try {
+    return db.deleteGroup(id);
+  } catch (err) {
+    log.error('delete-group error:', err);
+    return false;
+  }
+});
+
+// 切换分组折叠状态
+ipcMain.handle('toggle-group-collapsed', async (event, id) => {
+  try {
+    return db.toggleGroupCollapsed(id);
+  } catch (err) {
+    log.error('toggle-group-collapsed error:', err);
+    return false;
+  }
+});
+
+// 移动记录到分组
+ipcMain.handle('move-record-to-group', async (event, { recordId, groupId }) => {
+  try {
+    return db.moveRecordToGroup(recordId, groupId);
+  } catch (err) {
+    log.error('move-record-to-group error:', err);
+    return false;
+  }
+});
+
+// 更新记录排序
+ipcMain.handle('update-record-sort-order', async (event, { recordId, newOrder, newGroupId }) => {
+  try {
+    return db.updateRecordSortOrder(recordId, newOrder, newGroupId);
+  } catch (err) {
+    log.error('update-record-sort-order error:', err);
+    return false;
+  }
+});
+
+// 批量更新排序
+ipcMain.handle('batch-update-sort-order', async (event, updates) => {
+  try {
+    return db.batchUpdateSortOrder(updates);
+  } catch (err) {
+    log.error('batch-update-sort-order error:', err);
+    return false;
+  }
+});
+
 // 应用启动
 app.whenReady().then(async () => {
   log.info('应用准备就绪');

--- a/src/preload.js
+++ b/src/preload.js
@@ -51,6 +51,16 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   // v0.23.0: 保存记录（用于合并功能）
   saveRecord: (record) => ipcRenderer.invoke('save-record', record),
   
+  // v0.24.0: 分组管理
+  getAllGroups: () => ipcRenderer.invoke('get-all-groups'),
+  createGroup: (name, color, icon) => ipcRenderer.invoke('create-group', { name, color, icon }),
+  updateGroup: (id, updates) => ipcRenderer.invoke('update-group', { id, ...updates }),
+  deleteGroup: (id) => ipcRenderer.invoke('delete-group', id),
+  toggleGroupCollapsed: (id) => ipcRenderer.invoke('toggle-group-collapsed', id),
+  moveRecordToGroup: (recordId, groupId) => ipcRenderer.invoke('move-record-to-group', { recordId, groupId }),
+  updateRecordSortOrder: (recordId, newOrder, newGroupId) => ipcRenderer.invoke('update-record-sort-order', { recordId, newOrder, newGroupId }),
+  batchUpdateSortOrder: (updates) => ipcRenderer.invoke('batch-update-sort-order', updates),
+  
   // 事件监听
   onNewRecord: (callback) => {
     ipcRenderer.on('new-record', (event, record) => callback(record));

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -23,6 +23,12 @@
   let currentTag = null;
   // 预设标签颜色
   const tagColors = ['#f97316', '#3b82f6', '#22c55e', '#a855f7', '#ec4899', '#eab308', '#06b6d4', '#ef4444'];
+  
+  // 分组相关状态
+  let groups = [];
+  let currentGroupId = null; // null = 全部记录
+  let draggedRecord = null;
+  let draggedGroup = null;
 
   // ==================== DOM 元素 ====================
   const $ = (sel) => document.querySelector(sel);
@@ -43,6 +49,7 @@
   async function init() {
     setupEventListeners();
     initShortcutRecording();  // 初始化快捷键录制
+    await loadGroups();
     await loadRecords();
     await loadStats();
     setupIpcListeners();
@@ -190,6 +197,41 @@
     $('#btnBatchFavorite').addEventListener('click', handleBatchFavorite);
     $('#btnBatchDelete').addEventListener('click', handleBatchDelete);
     $('#btnBatchExport').addEventListener('click', handleBatchExport);
+    $('#btnBatchMoveToGroup').addEventListener('click', handleBatchMoveToGroup);
+
+    // 分组管理
+    $('#btnAddGroup').addEventListener('click', () => showGroupDialog());
+    $('#btnCloseGroup').addEventListener('click', () => $('#groupOverlay').classList.remove('show'));
+    $('#btnCancelGroup').addEventListener('click', () => $('#groupOverlay').classList.remove('show'));
+    $('#btnConfirmGroup').addEventListener('click', handleConfirmGroup);
+    $('#btnDeleteGroup').addEventListener('click', handleDeleteGroup);
+    $('#groupOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#groupOverlay')) $('#groupOverlay').classList.remove('show');
+    });
+
+    // 图标选择
+    $$('.icon-option').forEach(btn => {
+      btn.addEventListener('click', () => {
+        $$('.icon-option').forEach(b => b.classList.remove('selected'));
+        btn.classList.add('selected');
+        $('#selectedGroupIcon').value = btn.dataset.icon;
+      });
+    });
+
+    // 颜色选择
+    $$('.color-option').forEach(btn => {
+      btn.addEventListener('click', () => {
+        $$('.color-option').forEach(b => b.classList.remove('selected'));
+        btn.classList.add('selected');
+        $('#selectedGroupColor').value = btn.dataset.color;
+      });
+    });
+
+    // 移动到分组
+    $('#btnCloseMoveToGroup').addEventListener('click', () => $('#moveToGroupOverlay').classList.remove('show'));
+    $('#moveToGroupOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#moveToGroupOverlay')) $('#moveToGroupOverlay').classList.remove('show');
+    });
 
     // 合并对话框
     $('#btnCloseMerge').addEventListener('click', () => {
@@ -340,6 +382,11 @@
         options.tag = currentTag;
       }
 
+      // 按分组筛选
+      if (currentGroupId !== null) {
+        options.groupId = currentGroupId;
+      }
+
       if (searchQuery) {
         options.search = searchQuery;
         records = await window.ClawBoard.search(searchQuery);
@@ -354,6 +401,214 @@
       isLoading = false;
       loading.classList.remove('show');
     }
+  }
+
+  // ==================== 分组管理 ====================
+  async function loadGroups() {
+    try {
+      groups = await window.ClawBoard.getAllGroups();
+      renderGroups();
+    } catch (err) {
+      console.error('加载分组失败:', err);
+    }
+  }
+
+  function renderGroups() {
+    const groupsList = $('#groupsList');
+    groupsList.innerHTML = `
+      <div class="group-item ${currentGroupId === null ? 'active' : ''}" data-group-id="">
+        <span class="group-icon">📋</span>
+        <span class="group-name">全部记录</span>
+      </div>
+    `;
+
+    groups.forEach(group => {
+      const groupEl = document.createElement('div');
+      groupEl.className = `group-item ${currentGroupId === group.id ? 'active' : ''}`;
+      groupEl.dataset.groupId = group.id;
+      groupEl.draggable = true;
+      groupEl.innerHTML = `
+        <span class="group-icon" style="color:${group.color}">${group.icon}</span>
+        <span class="group-name">${escapeHtml(group.name)}</span>
+        <button class="group-edit" title="编辑">✏️</button>
+      `;
+
+      // 点击选择分组
+      groupEl.querySelector('.group-name').addEventListener('click', () => selectGroup(group.id));
+
+      // 点击编辑
+      groupEl.querySelector('.group-edit').addEventListener('click', (e) => {
+        e.stopPropagation();
+        showGroupDialog(group);
+      });
+
+      // 拖拽记录到分组
+      groupEl.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        groupEl.classList.add('drag-over');
+      });
+      groupEl.addEventListener('dragleave', () => {
+        groupEl.classList.remove('drag-over');
+      });
+      groupEl.addEventListener('drop', async (e) => {
+        e.preventDefault();
+        groupEl.classList.remove('drag-over');
+        if (draggedRecord) {
+          await window.ClawBoard.moveRecordToGroup(draggedRecord, group.id);
+          showToast(`已移动到 ${group.name}`, 'success');
+          draggedRecord = null;
+          loadRecords();
+        }
+      });
+
+      groupsList.appendChild(groupEl);
+    });
+
+    // "全部记录"点击事件
+    groupsList.querySelector('[data-group-id=""]').addEventListener('click', () => selectGroup(null));
+  }
+
+  function selectGroup(groupId) {
+    currentGroupId = groupId;
+    renderGroups();
+    loadRecords();
+  }
+
+  function showGroupDialog(group = null) {
+    const overlay = $('#groupOverlay');
+    const title = $('#groupDialogTitle');
+    const nameInput = $('#groupName');
+    const confirmBtn = $('#btnConfirmGroup');
+    const deleteBtn = $('#btnDeleteGroup');
+    const iconInput = $('#selectedGroupIcon');
+    const colorInput = $('#selectedGroupColor');
+
+    if (group) {
+      title.textContent = '✏️ 编辑分组';
+      nameInput.value = group.name;
+      confirmBtn.textContent = '保存';
+      deleteBtn.style.display = 'inline-block';
+      iconInput.value = group.icon;
+      colorInput.value = group.color;
+      overlay.dataset.groupId = group.id;
+
+      // 更新选中状态
+      $$('.icon-option').forEach(btn => {
+        btn.classList.toggle('selected', btn.dataset.icon === group.icon);
+      });
+      $$('.color-option').forEach(btn => {
+        btn.classList.toggle('selected', btn.dataset.color === group.color);
+      });
+    } else {
+      title.textContent = '📁 新建分组';
+      nameInput.value = '';
+      confirmBtn.textContent = '创建';
+      deleteBtn.style.display = 'none';
+      iconInput.value = '📁';
+      colorInput.value = '#3b82f6';
+      overlay.dataset.groupId = '';
+
+      // 重置选中状态
+      $$('.icon-option').forEach((btn, i) => btn.classList.toggle('selected', i === 0));
+      $$('.color-option').forEach((btn, i) => btn.classList.toggle('selected', i === 0));
+    }
+
+    overlay.classList.add('show');
+    nameInput.focus();
+  }
+
+  async function handleConfirmGroup() {
+    const overlay = $('#groupOverlay');
+    const groupId = overlay.dataset.groupId;
+    const name = $('#groupName').value.trim();
+    const icon = $('#selectedGroupIcon').value;
+    const color = $('#selectedGroupColor').value;
+
+    if (!name) {
+      showToast('请输入分组名称', 'error');
+      return;
+    }
+
+    try {
+      if (groupId) {
+        await window.ClawBoard.updateGroup(parseInt(groupId), { name, icon, color });
+        showToast('✅ 分组已更新', 'success');
+      } else {
+        await window.ClawBoard.createGroup(name, color, icon);
+        showToast('✅ 分组已创建', 'success');
+      }
+      overlay.classList.remove('show');
+      await loadGroups();
+    } catch (err) {
+      showToast('❌ 操作失败', 'error');
+    }
+  }
+
+  async function handleDeleteGroup() {
+    const overlay = $('#groupOverlay');
+    const groupId = overlay.dataset.groupId;
+    if (!groupId) return;
+
+    if (!confirm('确定要删除这个分组吗？分组内的记录将移到"未分组"。')) return;
+
+    try {
+      await window.ClawBoard.deleteGroup(parseInt(groupId));
+      showToast('🗑️ 分组已删除', 'success');
+      overlay.classList.remove('show');
+      if (currentGroupId === parseInt(groupId)) {
+        currentGroupId = null;
+      }
+      await loadGroups();
+      await loadRecords();
+    } catch (err) {
+      showToast('❌ 删除失败', 'error');
+    }
+  }
+
+  async function handleBatchMoveToGroup() {
+    if (selectedIds.size === 0) return;
+    await showMoveToGroupDialog();
+  }
+
+  async function showMoveToGroupDialog() {
+    const overlay = $('#moveToGroupOverlay');
+    const list = $('#moveToGroupList');
+
+    // 渲染分组列表
+    let html = `
+      <div class="move-group-item" data-group-id="">
+        <span class="group-icon">📋</span>
+        <span>未分组</span>
+      </div>
+    `;
+
+    for (const group of groups) {
+      html += `
+        <div class="move-group-item" data-group-id="${group.id}">
+          <span class="group-icon" style="color:${group.color}">${group.icon}</span>
+          <span>${escapeHtml(group.name)}</span>
+        </div>
+      `;
+    }
+
+    list.innerHTML = html;
+
+    // 绑定点击事件
+    list.querySelectorAll('.move-group-item').forEach(item => {
+      item.addEventListener('click', async () => {
+        const targetGroupId = item.dataset.groupId === '' ? null : parseInt(item.dataset.groupId);
+        const ids = Array.from(selectedIds);
+        for (const id of ids) {
+          await window.ClawBoard.moveRecordToGroup(id, targetGroupId);
+        }
+        overlay.classList.remove('show');
+        setMultiSelectMode(false);
+        showToast(`已移动 ${ids.length} 条记录`, 'success');
+        await loadRecords();
+      });
+    });
+
+    overlay.classList.add('show');
   }
 
   async function loadStats() {
@@ -807,6 +1062,38 @@
       } else {
         openDetailPanel(record);
       }
+    });
+
+    // 拖拽排序
+    card.draggable = true;
+    card.addEventListener('dragstart', (e) => {
+      draggedRecord = record.id;
+      card.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+    });
+    card.addEventListener('dragend', () => {
+      card.classList.remove('dragging');
+      draggedRecord = null;
+    });
+    card.addEventListener('dragover', (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+    });
+    card.addEventListener('drop', async (e) => {
+      e.preventDefault();
+      if (!draggedRecord || draggedRecord === record.id) return;
+      
+      // 交换排序顺序
+      const draggedRecordData = records.find(r => r.id === draggedRecord);
+      if (!draggedRecordData) return;
+      
+      const updates = [
+        { id: draggedRecord, sort_order: record.sort_order || 0, group_id: draggedRecordData.group_id },
+        { id: record.id, sort_order: (record.sort_order || 0) + 1, group_id: record.group_id }
+      ];
+      
+      await window.ClawBoard.batchUpdateSortOrder(updates);
+      await loadRecords();
     });
 
     return card;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,6 +7,7 @@
   <title>🦞 ClawBoard</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@300;400;500;700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles_extra.css">
   <!-- Highlight.js 代码高亮样式 -->
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github-dark.min.css">
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
@@ -56,8 +57,23 @@
     <button class="batch-btn" id="btnBatchMerge" title="合并内容">🔗 合并</button>
     <button class="batch-btn" id="btnBatchFavorite" title="批量收藏">⭐ 收藏</button>
     <button class="batch-btn" id="btnBatchExport" title="批量导出">📥 导出</button>
+    <button class="batch-btn" id="btnBatchMoveToGroup" title="移动到分组">📁 移动</button>
     <button class="batch-btn danger" id="btnBatchDelete" title="批量删除">🗑️ 删除</button>
     <button class="batch-close" id="btnExitMultiSelect">取消</button>
+  </div>
+
+  <!-- 分组侧边栏 -->
+  <div class="groups-sidebar" id="groupsSidebar">
+    <div class="groups-header">
+      <span>📁 分组</span>
+      <button class="icon-btn-sm" id="btnAddGroup" title="新建分组">+</button>
+    </div>
+    <div class="groups-list" id="groupsList">
+      <div class="group-item active" data-group-id="">
+        <span class="group-icon">📋</span>
+        <span class="group-name">全部记录</span>
+      </div>
+    </div>
   </div>
 
   <!-- 主内容 -->
@@ -343,6 +359,68 @@
       <div class="settings-footer">
         <button class="btn-secondary" id="btnCancelMerge">取消</button>
         <button class="btn-primary" id="btnConfirmMerge">确认合并</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 新建分组对话框 -->
+  <div class="settings-overlay" id="groupOverlay">
+    <div class="encryption-panel" style="width:400px">
+      <div class="encryption-header">
+        <h2 id="groupDialogTitle">📁 新建分组</h2>
+        <button class="detail-close" id="btnCloseGroup">×</button>
+      </div>
+      <div class="encryption-body">
+        <div class="setting-item">
+          <label>分组名称</label>
+          <input type="text" id="groupName" placeholder="例如：工作、代码片段">
+        </div>
+        <div class="setting-item">
+          <label>分组图标</label>
+          <div class="group-icon-picker">
+            <button class="icon-option selected" data-icon="📁">📁</button>
+            <button class="icon-option" data-icon="💼">💼</button>
+            <button class="icon-option" data-icon="🏠">🏠</button>
+            <button class="icon-option" data-icon="💻">💻</button>
+            <button class="icon-option" data-icon="🎨">🎨</button>
+            <button class="icon-option" data-icon="📝">📝</button>
+            <button class="icon-option" data-icon="🔗">🔗</button>
+            <button class="icon-option" data-icon="📚">📚</button>
+          </div>
+          <input type="hidden" id="selectedGroupIcon" value="📁">
+        </div>
+        <div class="setting-item">
+          <label>分组颜色</label>
+          <div class="group-color-picker">
+            <button class="color-option selected" data-color="#3b82f6" style="background:#3b82f6"></button>
+            <button class="color-option" data-color="#22c55e" style="background:#22c55e"></button>
+            <button class="color-option" data-color="#f97316" style="background:#f97316"></button>
+            <button class="color-option" data-color="#a855f7" style="background:#a855f7"></button>
+            <button class="color-option" data-color="#ec4899" style="background:#ec4899"></button>
+            <button class="color-option" data-color="#eab308" style="background:#eab308"></button>
+            <button class="color-option" data-color="#06b6d4" style="background:#06b6d4"></button>
+            <button class="color-option" data-color="#ef4444" style="background:#ef4444"></button>
+          </div>
+          <input type="hidden" id="selectedGroupColor" value="#3b82f6">
+        </div>
+      </div>
+      <div class="settings-footer">
+        <button class="btn-secondary" id="btnDeleteGroup" style="display:none">删除分组</button>
+        <button class="btn-secondary" id="btnCancelGroup">取消</button>
+        <button class="btn-primary" id="btnConfirmGroup">创建</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 移动到分组对话框 -->
+  <div class="settings-overlay" id="moveToGroupOverlay">
+    <div class="encryption-panel" style="width:360px">
+      <div class="encryption-header">
+        <h2>📁 移动到分组</h2>
+        <button class="detail-close" id="btnCloseMoveToGroup">×</button>
+      </div>
+      <div class="encryption-body">
+        <div class="move-to-group-list" id="moveToGroupList"></div>
       </div>
     </div>
   </div>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -1,0 +1,35 @@
+
+/* v0.24.0: 分组管理样式 */
+.groups-sidebar{position:fixed;left:0;top:108px;bottom:0;width:200px;background:var(--surface);border-right:1px solid var(--border);z-index:30;display:flex;flex-direction:column;transform:translateX(-100%);transition:transform 0.3s ease}
+.groups-sidebar.show{transform:translateX(0)}
+.groups-header{display:flex;align-items:center;justify-content:space-between;padding:0.8rem 1rem;border-bottom:1px solid var(--border);font-weight:600}
+.icon-btn-sm{width:24px;height:24px;border-radius:4px;background:var(--surface2);color:var(--text);font-size:0.9rem;display:flex;align-items:center;justify-content:center;transition:all 0.2s}
+.icon-btn-sm:hover{background:var(--accent-bg);color:var(--accent)}
+.groups-list{flex:1;overflow-y:auto;padding:0.5rem}
+.group-item{display:flex;align-items:center;padding:0.6rem 0.8rem;border-radius:8px;cursor:pointer;transition:all 0.2s;gap:0.5rem}
+.group-item:hover{background:rgba(255,255,255,0.05)}
+.group-item.active{background:var(--accent-bg)}
+.group-item.active .group-name{color:var(--accent);font-weight:600}
+.group-icon{font-size:1rem}
+.group-name{font-size:0.85rem;color:var(--text);flex:1}
+.group-edit{font-size:0.75rem;padding:0.2rem 0.4rem;background:transparent;color:var(--muted);border-radius:4px;opacity:0;transition:opacity 0.2s}
+.group-item:hover .group-edit{opacity:1}
+.group-edit:hover{color:var(--accent);background:rgba(255,255,255,0.1)}
+.group-item.drag-over{background:var(--accent-bg);outline:2px dashed var(--accent)}
+.groups-sidebar.show~.main{left:200px}
+
+/* 分组对话框 */
+.group-icon-picker,.group-color-picker{display:flex;gap:0.5rem;flex-wrap:wrap}
+.icon-option,.color-option{width:36px;height:36px;border-radius:8px;border:2px solid var(--border);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all 0.2s;font-size:1rem}
+.icon-option:hover,.color-option:hover{border-color:var(--accent)}
+.icon-option.selected,.color-option.selected{border-color:var(--accent);background:var(--accent-bg)}
+.color-option{width:28px;height:28px}
+
+/* 移动到分组对话框 */
+.move-to-group-list{display:flex;flex-direction:column;gap:0.5rem}
+.move-group-item{display:flex;align-items:center;padding:0.8rem 1rem;background:var(--surface);border:1px solid var(--border);border-radius:8px;cursor:pointer;transition:all 0.2s;gap:0.8rem}
+.move-group-item:hover{border-color:var(--accent);background:var(--accent-bg)}
+
+/* 拖拽排序样式 */
+.record-card.dragging{opacity:0.5;transform:scale(0.98)}
+.record-card.drag-over{border-color:var(--accent);outline:2px dashed var(--accent)}


### PR DESCRIPTION
## 功能概述

实现 Issue #50 - 拖拽排序与分组管理功能。

## 主要改动

### 数据库层
- 添加 sort_order 和 group_id 字段
- 创建 groups 表管理分组
- 添加分组 CRUD 方法

### IPC 处理器
- get-all-groups, create-group, update-group, delete-group
- move-record-to-group, batch-update-sort-order

### UI 功能
- 分组侧边栏
- 新建/编辑分组对话框
- 拖拽记录排序和移动
- 批量移动到分组

## 测试建议

1. 创建新分组并设置图标颜色
2. 拖拽记录调整顺序
3. 将记录拖入分组
4. 批量选择记录并移动到分组