### PR TITLE
feat: v0.25.0 - 剪贴板历史统计导出

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1015,6 +1015,129 @@ class Database {
     return true;
   }
 
+  // v0.25.0: 统计数据导出
+  getDetailedStatsForExport() {
+    const stats = this.getStats();
+    const detailedStats = this.getDetailedStats();
+
+    // 按类型获取记录
+    const typeRecords = {};
+    const types = ['text', 'code', 'file', 'image'];
+    for (const type of types) {
+      const result = this.db.exec(
+        `SELECT id, content, created_at FROM records WHERE type = ? ORDER BY created_at DESC`,
+        [type]
+      );
+      if (result.length > 0) {
+        typeRecords[type] = result[0].values.map(row => ({
+          id: row[0],
+          content: row[1],
+          created_at: row[2]
+        }));
+      } else {
+        typeRecords[type] = [];
+      }
+    }
+
+    // 按来源应用获取记录
+    const sourceRecords = {};
+    const sourceResult = this.db.exec(
+      `SELECT source_app, COUNT(*) as count FROM records WHERE source_app IS NOT NULL GROUP BY source_app ORDER BY count DESC LIMIT 20`
+    );
+    if (sourceResult.length > 0) {
+      sourceResult[0].values.forEach(row => {
+        sourceRecords[row[0]] = row[1];
+      });
+    }
+
+    // 按标签统计
+    const tagRecords = {};
+    const tagResult = this.db.exec(`SELECT id, tags FROM records WHERE tags IS NOT NULL AND tags != ''`);
+    if (tagResult.length > 0) {
+      tagResult[0].values.forEach(row => {
+        try {
+          const tags = JSON.parse(row[1]);
+          tags.forEach(tag => {
+            tagRecords[tag] = (tagRecords[tag] || 0) + 1;
+          });
+        } catch (e) {}
+      });
+    }
+
+    return {
+      summary: stats,
+      detailed: detailedStats,
+      byType: typeRecords,
+      bySource: sourceRecords,
+      byTag: tagRecords
+    };
+  }
+
+  // 导出记录为指定格式
+  exportRecords(format = 'json', options = {}) {
+    let sql = 'SELECT * FROM records WHERE 1=1';
+    const params = [];
+
+    if (options.type) {
+      sql += ' AND type = ?';
+      params.push(options.type);
+    }
+
+    if (options.startDate) {
+      sql += ' AND created_at >= ?';
+      params.push(options.startDate);
+    }
+
+    if (options.endDate) {
+      sql += ' AND created_at <= ?';
+      params.push(options.endDate);
+    }
+
+    if (options.favorite) {
+      sql += ' AND favorite = 1';
+    }
+
+    sql += ' ORDER BY created_at DESC';
+
+    const result = this.db.exec(sql, params);
+    if (result.length === 0) return [];
+
+    const records = result[0].values.map(row => this._rowToRecord(result[0].columns, row));
+
+    switch (format) {
+      case 'csv':
+        return this._recordsToCSV(records);
+      case 'json':
+      default:
+        return JSON.stringify(records, null, 2);
+    }
+  }
+
+  _recordsToCSV(records) {
+    if (records.length === 0) return '';
+
+    const headers = ['id', 'type', 'content', 'created_at', 'favorite', 'source_app', 'language', 'tags'];
+    const rows = [headers.join(',')];
+
+    for (const record of records) {
+      const row = headers.map(h => {
+        let value = record[h];
+        if (value === null || value === undefined) return '';
+        if (typeof value === 'string') {
+          // 处理 CSV 中的特殊字符
+          value = value.replace(/"/g, '""');
+          if (value.includes(',') || value.includes('\n') || value.includes('"')) {
+            value = `"${value}"`;
+          }
+        }
+        return value;
+      });
+      rows.push(row.join(','));
+    }
+
+    return rows.join('\n');
+  }
+
   // 辅助：将列和值转为对象
   _rowToRecord(columns, values) {
     if (!values) return null;

--- a/src/main.js
+++ b/src/main.js
@@ -687,6 +687,48 @@ ipcMain.handle('batch-update-sort-order', async (event, updates) => {
   }
 });
 
+// v0.25.0: 统计导出
+ipcMain.handle('get-stats-for-export', async () => {
+  try {
+    return db.getDetailedStatsForExport();
+  } catch (err) {
+    log.error('get-stats-for-export error:', err);
+    return null;
+  }
+});
+
+// v0.25.0: 导出记录
+ipcMain.handle('export-records', async (event, { format, options }) => {
+  try {
+    return db.exportRecords(format, options);
+  } catch (err) {
+    log.error('export-records error:', err);
+    return null;
+  }
+});
+
+// v0.25.0: 保存导出文件
+ipcMain.handle('save-export-file', async (event, { content, filename }) => {
+  try {
+    const { dialog } = require('electron');
+    const fs = require('fs');
+    const result = await dialog.showSaveDialog({
+      defaultPath: filename,
+      filters: [
+        { name: 'JSON', extensions: ['json'] },
+        { name: 'CSV', extensions: ['csv'] },
+        { name: '所有文件', extensions: ['*'] }
+      ]
+    });
+    if (result.canceled) return { success: false, canceled: true };
+    fs.writeFileSync(result.filePath, content, 'utf8');
+    return { success: true, path: result.filePath };
+  } catch (err) {
+    log.error('save-export-file error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
 // 应用启动
 app.whenReady().then(async () => {
   log.info('应用准备就绪');

--- a/src/preload.js
+++ b/src/preload.js
@@ -60,6 +60,11 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   moveRecordToGroup: (recordId, groupId) => ipcRenderer.invoke('move-record-to-group', { recordId, groupId }),
   updateRecordSortOrder: (recordId, newOrder, newGroupId) => ipcRenderer.invoke('update-record-sort-order', { recordId, newOrder, newGroupId }),
   batchUpdateSortOrder: (updates) => ipcRenderer.invoke('batch-update-sort-order', updates),
+
+  // v0.25.0: 统计导出
+  getStatsForExport: () => ipcRenderer.invoke('get-stats-for-export'),
+  exportRecords: (format, options) => ipcRenderer.invoke('export-records', { format, options }),
+  saveExportFile: (content, filename) => ipcRenderer.invoke('save-export-file', { content, filename }),
   
   // 事件监听
   onNewRecord: (callback) => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -233,6 +233,15 @@
       if (e.target === $('#moveToGroupOverlay')) $('#moveToGroupOverlay').classList.remove('show');
     });
 
+    // 统计导出
+    $('#btnCloseExport').addEventListener('click', () => $('#exportOverlay').classList.remove('show'));
+    $('#exportOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#exportOverlay')) $('#exportOverlay').classList.remove('show');
+    });
+    $('#btnExportStatsJSON').addEventListener('click', () => handleExportStats('json'));
+    $('#btnExportStatsCSV').addEventListener('click', () => handleExportStats('csv'));
+    $('#btnExportRecords').addEventListener('click', handleExportRecords);
+
     // 合并对话框
     $('#btnCloseMerge').addEventListener('click', () => {
       $('#mergeOverlay').classList.remove('show');
@@ -261,6 +270,24 @@
       $('#statsOverlay').classList.add('show');
       await loadDetailedStats();
     });
+
+    // 统计导出按钮
+    const originalLoadDetailedStats = loadDetailedStats;
+    window.loadDetailedStats = async function() {
+      await originalLoadDetailedStats();
+      // 添加导出按钮
+      const statsContent = $('#statsContent');
+      const exportBtn = document.createElement('button');
+      exportBtn.className = 'btn-secondary';
+      exportBtn.style.marginTop = '1rem';
+      exportBtn.style.width = '100%';
+      exportBtn.textContent = '📥 导出统计报告';
+      exportBtn.addEventListener('click', () => {
+        $('#statsOverlay').classList.remove('show');
+        $('#exportOverlay').classList.add('show');
+      });
+      statsContent.appendChild(exportBtn);
+    };
 
     // 标签面板
     $('#btnTags').addEventListener('click', async () => {
@@ -562,6 +589,81 @@
       await loadRecords();
     } catch (err) {
       showToast('❌ 删除失败', 'error');
+    }
+  }
+
+  // ==================== 统计导出 ====================
+  async function handleExportStats(format) {
+    try {
+      showToast('正在生成统计报告...', '');
+      const stats = await window.ClawBoard.getStatsForExport();
+      if (!stats) {
+        showToast('❌ 获取统计数据失败', 'error');
+        return;
+      }
+
+      let content;
+      let filename;
+      const timestamp = new Date().toISOString().slice(0, 10);
+
+      if (format === 'csv') {
+        // 生成 CSV 格式
+        const rows = ['类别,项目,数值'];
+        rows.push(`总统计,总记录数,${stats.summary.total}`);
+        rows.push(`总统计,今日新增,${stats.summary.today}`);
+        rows.push(`总统计,本周新增,${stats.summary.week}`);
+        rows.push(`总统计,收藏数,${stats.summary.favorite}`);
+        rows.push(`总统计,加密数,${stats.summary.encrypted}`);
+        rows.push(`类型分布,文字,${stats.detailed.typePercent.text || 0}%`);
+        rows.push(`类型分布,代码,${stats.detailed.typePercent.code || 0}%`);
+        rows.push(`类型分布,文件,${stats.detailed.typePercent.file || 0}%`);
+        rows.push(`类型分布,图片,${stats.detailed.typePercent.image || 0}%`);
+        content = rows.join('\n');
+        filename = `clawboard_stats_${timestamp}.csv`;
+      } else {
+        content = JSON.stringify(stats, null, 2);
+        filename = `clawboard_stats_${timestamp}.json`;
+      }
+
+      const result = await window.ClawBoard.saveExportFile(content, filename);
+      if (result.success) {
+        showToast('✅ 统计报告已保存', 'success');
+      } else if (!result.canceled) {
+        showToast('❌ 保存失败', 'error');
+      }
+    } catch (err) {
+      console.error('导出统计失败:', err);
+      showToast('❌ 导出失败', 'error');
+    }
+  }
+
+  async function handleExportRecords() {
+    try {
+      const format = $('#exportFormat').value;
+      const type = $('#exportType').value;
+      const favorite = $('#exportFavorite').checked;
+
+      showToast('正在导出记录...', '');
+      const content = await window.ClawBoard.exportRecords(format, { type, favorite });
+
+      if (!content) {
+        showToast('❌ 无记录可导出', 'error');
+        return;
+      }
+
+      const timestamp = new Date().toISOString().slice(0, 10);
+      const filename = `clawboard_records_${timestamp}.${format}`;
+
+      const result = await window.ClawBoard.saveExportFile(content, filename);
+      if (result.success) {
+        showToast('✅ 记录已导出', 'success');
+        $('#exportOverlay').classList.remove('show');
+      } else if (!result.canceled) {
+        showToast('❌ 保存失败', 'error');
+      }
+    } catch (err) {
+      console.error('导出记录失败:', err);
+      showToast('❌ 导出失败', 'error');
     }
   }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -425,6 +425,56 @@
     </div>
   </div>
 
+  <!-- 统计导出对话框 -->
+  <div class="settings-overlay" id="exportOverlay">
+    <div class="encryption-panel" style="width:480px;max-height:80vh">
+      <div class="encryption-header">
+        <h2>📊 统计导出</h2>
+        <button class="detail-close" id="btnCloseExport">×</button>
+      </div>
+      <div class="encryption-body">
+        <div class="export-section">
+          <h3>📈 完整统计报告</h3>
+          <p class="export-desc">导出包含所有统计数据的详细报告</p>
+          <div class="export-actions">
+            <button class="export-btn" id="btnExportStatsJSON">📋 JSON 报告</button>
+            <button class="export-btn" id="btnExportStatsCSV">📊 CSV 报告</button>
+          </div>
+        </div>
+        <div class="export-section">
+          <h3>📋 记录导出</h3>
+          <p class="export-desc">导出剪贴板历史记录</p>
+          <div class="export-filters">
+            <div class="export-filter-item">
+              <label>格式</label>
+              <select id="exportFormat">
+                <option value="json">JSON</option>
+                <option value="csv">CSV</option>
+              </select>
+            </div>
+            <div class="export-filter-item">
+              <label>类型</label>
+              <select id="exportType">
+                <option value="">全部</option>
+                <option value="text">文字</option>
+                <option value="code">代码</option>
+                <option value="file">文件</option>
+                <option value="image">图片</option>
+              </select>
+            </div>
+            <div class="export-filter-item">
+              <label>
+                <input type="checkbox" id="exportFavorite">
+                仅收藏
+              </label>
+            </div>
+          </div>
+          <button class="export-btn full" id="btnExportRecords">📥 导出记录</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast 通知 -->
   <div class="toast" id="toast">
     <span id="toastMessage"></span>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -33,3 +33,18 @@
 /* 拖拽排序样式 */
 .record-card.dragging{opacity:0.5;transform:scale(0.98)}
 .record-card.drag-over{border-color:var(--accent);outline:2px dashed var(--accent)}
+
+/* v0.25.0: 统计导出样式 */
+.export-section{margin-bottom:1.5rem;padding-bottom:1rem;border-bottom:1px solid var(--border)}
+.export-section:last-child{border-bottom:none}
+.export-section h3{font-size:1rem;margin-bottom:0.5rem}
+.export-desc{font-size:0.85rem;color:var(--muted);margin-bottom:0.8rem}
+.export-actions{display:flex;gap:0.5rem}
+.export-btn{padding:0.6rem 1rem;border-radius:8px;font-size:0.85rem;background:var(--surface);color:var(--text);border:1px solid var(--border);transition:all 0.2s;flex:1}
+.export-btn:hover{border-color:var(--accent);background:var(--accent-bg);color:var(--accent)}
+.export-btn.full{width:100%}
+.export-filters{display:flex;gap:1rem;margin-bottom:1rem;flex-wrap:wrap}
+.export-filter-item{min-width:100px}
+.export-filter-item label{font-size:0.85rem;color:var(--text);display:block;margin-bottom:0.3rem}
+.export-filter-item select{width:100%;height:32px;padding:0 0.6rem;border:1px solid var(--border);border-radius:6px;background:var(--surface);color:var(--text);font-size:0.85rem}
+.export-filter-item input[type="checkbox"]{width:16px;height:16px;accent-color:var(--accent)}


### PR DESCRIPTION
## 功能概述

实现 Issue #49 - 剪贴板历史统计导出功能。

## 主要改动

### 数据库层
- 添加 getDetailedStatsForExport() 方法获取完整统计数据
- 添加 exportRecords() 方法支持 JSON/CSV 格式导出
- 添加 _recordsToCSV() CSV 格式转换

### IPC 处理器
- get-stats-for-export: 获取完整统计数据
- export-records: 按条件导出记录
- save-export-file: 保存导出文件

### UI 功能
- 统计导出对话框
- 完整统计报告导出（JSON/CSV）
- 记录导出（按类型、收藏筛选）
- 统计面板添加导出入口按钮

## 测试建议

1. 打开统计面板，点击导出按钮
2. 选择导出格式（JSON/CSV）
3. 测试记录导出筛选功能
4. 验证保存文件功能