### PR TITLE
feat: 云端同步功能 v0.28.0

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -85,15 +85,16 @@ class Database {
         language TEXT,
         locked INTEGER DEFAULT 0,
         encrypted INTEGER DEFAULT 0,
+        synced INTEGER DEFAULT 0,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `);
 
     // 添加新列（如果不存在）
-    ['source_app', 'source_title', 'source_url'].forEach(col => {
+    ['source_app', 'source_title', 'source_url', 'synced'].forEach(col => {
       try {
-        this.db.run(`ALTER TABLE records ADD COLUMN ${col} TEXT`);
+        this.db.run(`ALTER TABLE records ADD COLUMN ${col} ${col === 'synced' ? 'INTEGER DEFAULT 0' : 'TEXT'}`);
       } catch (e) {
         // 列已存在，忽略
       }
@@ -1337,6 +1338,321 @@ class Database {
     const sizes = ['B', 'KB', 'MB', 'GB'];
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+  }
+
+  // v0.28.0: 云端同步功能
+
+  /**
+   * 获取同步元数据
+   */
+  getSyncMetadata() {
+    const stats = this.getStats();
+    const settings = this.getSettings();
+    
+    // 获取上次同步时间
+    let lastSyncTime = null;
+    try {
+      const syncInfo = this.db.exec(`
+        SELECT value FROM settings WHERE key = 'last_sync_time'
+      `);
+      if (syncInfo.length > 0 && syncInfo[0].values.length > 0) {
+        lastSyncTime = syncInfo[0].values[0][0];
+      }
+    } catch (e) {}
+
+    // 获取同步配置
+    let syncConfig = null;
+    try {
+      const configResult = this.db.exec(`
+        SELECT value FROM settings WHERE key = 'sync_config'
+      `);
+      if (configResult.length > 0 && configResult[0].values.length > 0) {
+        syncConfig = JSON.parse(configResult[0].values[0][0]);
+      }
+    } catch (e) {
+      syncConfig = null;
+    }
+
+    return {
+      lastSyncTime,
+      totalRecords: stats.total,
+      syncedRecords: this._getSyncedCount(),
+      pendingRecords: stats.total - this._getSyncedCount(),
+      config: syncConfig,
+    };
+  }
+
+  _getSyncedCount() {
+    try {
+      const result = this.db.exec(`
+        SELECT COUNT(*) FROM records WHERE synced = 1
+      `);
+      return result[0]?.values[0][0] || 0;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  /**
+   * 保存同步配置
+   */
+  saveSyncConfig(config) {
+    this.db.run(`
+      INSERT OR REPLACE INTO settings (key, value) VALUES ('sync_config', ?)
+    `, [JSON.stringify(config)]);
+    this._save();
+    return true;
+  }
+
+  /**
+   * 更新最后同步时间
+   */
+  updateLastSyncTime() {
+    const now = new Date().toISOString();
+    this.db.run(`
+      INSERT OR REPLACE INTO settings (key, value) VALUES ('last_sync_time', ?)
+    `, [now]);
+    this._save();
+    return now;
+  }
+
+  /**
+   * 获取可同步的记录（用于上传）
+   * @param {Object} options - 筛选选项
+   * @param {boolean} options.onlyFavorites - 仅同步收藏
+   * @param {string} options.since - 仅获取指定时间后的记录
+   * @param {number} options.limit - 限制数量
+   */
+  getSyncableRecords({ onlyFavorites = false, since = null, limit = 100 } = {}) {
+    let sql = 'SELECT * FROM records WHERE 1=1';
+    const params = [];
+
+    if (onlyFavorites) {
+      sql += ' AND favorite = 1';
+    }
+
+    if (since) {
+      sql += ' AND updated_at >= ?';
+      params.push(since);
+    }
+
+    sql += ' ORDER BY updated_at DESC LIMIT ?';
+    params.push(limit);
+
+    const result = this.db.exec(sql, params);
+    if (result.length === 0) return [];
+
+    return result[0].values.map(row => this._rowToRecord(result[0].columns, row));
+  }
+
+  /**
+   * 导出数据用于同步（支持加密）
+   * @param {Object} options - 导出选项
+   */
+  exportForSync({ 
+    records = null,     // 指定记录，不指定则导出所有
+    includeSettings = true,
+    encrypt = false,
+    encryptionKey = null
+  } = {}) {
+    // 获取要导出的记录
+    const recordsToExport = records || this.getSyncableRecords({ limit: 10000 });
+
+    // 构建导出数据
+    const exportData = {
+      version: '1.0',
+      exportedAt: new Date().toISOString(),
+      recordCount: recordsToExport.length,
+      records: recordsToExport.map(r => ({
+        ...r,
+        // 不包含敏感字段
+        synced: undefined,
+      })),
+    };
+
+    if (includeSettings) {
+      exportData.settings = this.getSettings();
+    }
+
+    // 如果需要加密
+    if (encrypt && encryptionKey) {
+      const crypto = require('crypto');
+      const iv = crypto.randomBytes(16);
+      const key = crypto.scryptSync(encryptionKey, 'salt', 32);
+      const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+      
+      let encrypted = cipher.update(JSON.stringify(exportData), 'utf8', 'hex');
+      encrypted += cipher.final('hex');
+      const authTag = cipher.getAuthTag().toString('hex');
+
+      return {
+        encrypted: true,
+        iv: iv.toString('hex'),
+        authTag,
+        data: encrypted,
+      };
+    }
+
+    return {
+      encrypted: false,
+      data: exportData,
+    };
+  }
+
+  /**
+   * 从同步数据导入
+   * @param {Object} syncData - 同步数据
+   * @param {string} encryptionKey - 解密密钥（如果数据加密）
+   * @param {Object} options - 导入选项
+   */
+  importFromSync(syncData, encryptionKey = null, { 
+    conflictMode = 'newer',  // newer: 保留较新的, local: 保留本地, remote: 保留远程
+    skipExisting = true,
+  } = {}) {
+    let importData = syncData;
+
+    // 如果数据加密，先解密
+    if (syncData.encrypted && encryptionKey) {
+      try {
+        const crypto = require('crypto');
+        const iv = Buffer.from(syncData.iv, 'hex');
+        const authTag = Buffer.from(syncData.authTag, 'hex');
+        const key = crypto.scryptSync(encryptionKey, 'salt', 32);
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+        decipher.setAuthTag(authTag);
+
+        let decrypted = decipher.update(syncData.data, 'hex', 'utf8');
+        decrypted += decipher.final('utf8');
+        importData = JSON.parse(decrypted);
+      } catch (e) {
+        throw new Error('解密失败，请检查密钥是否正确');
+      }
+    }
+
+    if (!importData.records) {
+      throw new Error('无效的同步数据格式');
+    }
+
+    let imported = 0;
+    let skipped = 0;
+    let conflicts = 0;
+
+    for (const record of importData.records) {
+      const existing = this.db.exec(`
+        SELECT * FROM records WHERE content = ? AND type = ?
+      `, [record.content, record.type]);
+
+      if (existing.length > 0 && existing[0].values.length > 0) {
+        if (skipExisting) {
+          skipped++;
+          continue;
+        }
+
+        if (conflictMode === 'newer') {
+          const existingRecord = this._rowToRecord(existing[0].columns, existing[0].values[0]);
+          const existingTime = new Date(existingRecord.updated_at);
+          const incomingTime = new Date(record.updated_at);
+
+          if (incomingTime > existingTime) {
+            // 更新本地记录
+            this.db.run(`
+              UPDATE records SET 
+                content = ?, summary = ?, tags = ?, favorite = ?,
+                updated_at = ?, synced = 1
+              WHERE id = ?
+            `, [record.content, record.summary, record.tags, record.favorite, record.updated_at, existingRecord.id]);
+            imported++;
+          } else {
+            conflicts++;
+          }
+        }
+      } else {
+        // 新增记录
+        this.db.run(`
+          INSERT INTO records (content, type, summary, tags, favorite, source_app, encrypted, created_at, updated_at, synced)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
+        `, [
+          record.content,
+          record.type,
+          record.summary,
+          record.tags,
+          record.favorite,
+          record.source_app,
+          record.encrypted,
+          record.created_at,
+          record.updated_at
+        ]);
+        imported++;
+      }
+    }
+
+    this._save();
+
+    return {
+      imported,
+      skipped,
+      conflicts,
+      total: importData.records.length,
+    };
+  }
+
+  /**
+   * 标记记录为已同步
+   */
+  markAsSynced(ids) {
+    if (!Array.isArray(ids) || ids.length === 0) return 0;
+
+    const placeholders = ids.map(() => '?').join(',');
+    this.db.run(`UPDATE records SET synced = 1 WHERE id IN (${placeholders})`, ids);
+    this._save();
+    return ids.length;
+  }
+
+  /**
+   * 获取同步统计
+   */
+  getSyncStats() {
+    const total = this.getStats().total;
+    const synced = this._getSyncedCount();
+    const pending = total - synced;
+
+    // 获取待同步记录的类型分布
+    const byType = {};
+    try {
+      const result = this.db.exec(`
+        SELECT type, COUNT(*) as count
+        FROM records WHERE synced = 0
+        GROUP BY type
+      `);
+      if (result.length > 0) {
+        result[0].values.forEach(([type, count]) => {
+          byType[type] = count;
+        });
+      }
+    } catch (e) {}
+
+    // 获取最早和最新的待同步记录时间
+    let oldestPending = null;
+    let newestPending = null;
+    try {
+      const timeResult = this.db.exec(`
+        SELECT MIN(created_at), MAX(created_at) FROM records WHERE synced = 0
+      `);
+      if (timeResult.length > 0 && timeResult[0].values[0][0]) {
+        oldestPending = timeResult[0].values[0][0];
+        newestPending = timeResult[0].values[0][1];
+      }
+    } catch (e) {}
+
+    return {
+      total,
+      synced,
+      pending,
+      syncProgress: total > 0 ? Math.round((synced / total) * 100) : 100,
+      byType,
+      oldestPending,
+      newestPending,
+    };
   }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -807,6 +807,149 @@ ipcMain.handle('get-pinned-stats', async () => {
   }
 });
 
+// v0.28.0: 云端同步功能
+ipcMain.handle('get-sync-metadata', async () => {
+  try {
+    return db.getSyncMetadata();
+  } catch (err) {
+    log.error('get-sync-metadata error:', err);
+    return null;
+  }
+});
+
+ipcMain.handle('save-sync-config', async (_, config) => {
+  try {
+    return db.saveSyncConfig(config);
+  } catch (err) {
+    log.error('save-sync-config error:', err);
+    return false;
+  }
+});
+
+ipcMain.handle('get-sync-stats', async () => {
+  try {
+    return db.getSyncStats();
+  } catch (err) {
+    log.error('get-sync-stats error:', err);
+    return null;
+  }
+});
+
+ipcMain.handle('export-for-sync', async (_, options) => {
+  try {
+    return db.exportForSync(options);
+  } catch (err) {
+    log.error('export-for-sync error:', err);
+    return null;
+  }
+});
+
+ipcMain.handle('import-from-sync', async (_, syncData, encryptionKey, options) => {
+  try {
+    return db.importFromSync(syncData, encryptionKey, options);
+  } catch (err) {
+    log.error('import-from-sync error:', err);
+    return { error: err.message };
+  }
+});
+
+ipcMain.handle('test-webdav-connection', async (_, config) => {
+  try {
+    const { protocol, host, port, path, username, password } = config;
+    const url = `${protocol}://${host}:${port}${path}`;
+    
+    // 简单的连接测试 - 使用 fetch
+    const response = await fetch(url, {
+      method: 'PROPFIND',
+      headers: {
+        'Depth': '0',
+        'Authorization': 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64'),
+      },
+    });
+    
+    return { success: response.ok, status: response.status };
+  } catch (err) {
+    log.error('test-webdav-connection error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('sync-to-webdav', async (_, config) => {
+  try {
+    const { protocol, host, port, path, username, password, encrypt, encryptionKey } = config;
+    const url = `${protocol}://${host}:${port}${path}/clawboard-sync.json`;
+    
+    // 导出数据
+    const exportData = db.exportForSync({ encrypt, encryptionKey });
+    
+    // 上传到 WebDAV
+    const auth = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Authorization': auth,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(exportData),
+    });
+    
+    if (response.ok) {
+      // 更新同步时间
+      db.updateLastSyncTime();
+      
+      // 标记所有记录为已同步
+      const records = db.getSyncableRecords({ limit: 10000 });
+      const ids = records.map(r => r.id);
+      if (ids.length > 0) {
+        db.markAsSynced(ids);
+      }
+      
+      return { success: true, recordCount: ids.length };
+    }
+    
+    return { success: false, status: response.status };
+  } catch (err) {
+    log.error('sync-to-webdav error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+ipcMain.handle('sync-from-webdav', async (_, config) => {
+  try {
+    const { protocol, host, port, path, username, password, encryptionKey } = config;
+    const url = `${protocol}://${host}:${port}${path}/clawboard-sync.json`;
+    
+    // 从 WebDAV 下载
+    const auth = 'Basic ' + Buffer.from(`${username}:${password}`).toString('base64');
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': auth,
+      },
+    });
+    
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { success: false, error: '远程没有找到同步文件' };
+      }
+      return { success: false, status: response.status };
+    }
+    
+    const syncData = await response.json();
+    
+    // 导入数据
+    const result = db.importFromSync(syncData, encryptionKey);
+    
+    // 更新同步时间
+    db.updateLastSyncTime();
+    
+    return { success: true, ...result };
+  } catch (err) {
+    log.error('sync-from-webdav error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
 // 应用启动
 app.whenReady().then(async () => {
   log.info('应用准备就绪');

--- a/src/preload.js
+++ b/src/preload.js
@@ -83,6 +83,16 @@ contextBridge.exposeInMainWorld('ClawBoard', {
     ipcRenderer.on('focus-search', () => callback());
   },
   
+  // v0.28.0: 云端同步
+  getSyncMetadata: () => ipcRenderer.invoke('get-sync-metadata'),
+  saveSyncConfig: (config) => ipcRenderer.invoke('save-sync-config', config),
+  getSyncStats: () => ipcRenderer.invoke('get-sync-stats'),
+  exportForSync: (options) => ipcRenderer.invoke('export-for-sync', options),
+  importFromSync: (syncData, encryptionKey, options) => ipcRenderer.invoke('import-from-sync', syncData, encryptionKey, options),
+  testWebDAVConnection: (config) => ipcRenderer.invoke('test-webdav-connection', config),
+  syncToWebDAV: (config) => ipcRenderer.invoke('sync-to-webdav', config),
+  syncFromWebDAV: (config) => ipcRenderer.invoke('sync-from-webdav', config),
+
   // 移除监听
   removeAllListeners: (channel) => {
     ipcRenderer.removeAllListeners(channel);

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -310,6 +310,199 @@
       await loadPinnedList();
     });
 
+    // 云端同步面板 v0.28.0
+    $('#btnCloudSync').addEventListener('click', async () => {
+      $('#cloudSyncOverlay').classList.add('show');
+      await loadSyncPanel();
+    });
+    $('#btnCloseCloudSync').addEventListener('click', () => {
+      $('#cloudSyncOverlay').classList.remove('show');
+    });
+    $('#cloudSyncOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#cloudSyncOverlay')) {
+        $('#cloudSyncOverlay').classList.remove('show');
+      }
+    });
+
+    // 加密开关
+    $('#syncEncrypt').addEventListener('change', (e) => {
+      $('#syncEncryptKeyItem').style.display = e.target.checked ? 'block' : 'none';
+    });
+
+    // 测试连接
+    $('#btnTestConnection').addEventListener('click', async () => {
+      const config = getSyncConfigFromForm();
+      if (!config.host) {
+        showToast('请填写服务器地址', 'error');
+        return;
+      }
+      
+      $('#btnTestConnection').disabled = true;
+      $('#btnTestConnection').textContent = '🔄 测试中...';
+      
+      try {
+        const result = await window.ClawBoard.testWebDAVConnection(config);
+        if (result.success) {
+          showToast('连接成功！');
+        } else {
+          showToast(`连接失败: ${result.error || result.status}`, 'error');
+        }
+      } catch (err) {
+        showToast('测试失败: ' + err.message, 'error');
+      }
+      
+      $('#btnTestConnection').disabled = false;
+      $('#btnTestConnection').textContent = '🔗 测试连接';
+    });
+
+    // 保存配置
+    $('#btnSaveSyncConfig').addEventListener('click', async () => {
+      const config = getSyncConfigFromForm();
+      
+      try {
+        await window.ClawBoard.saveSyncConfig(config);
+        showToast('配置已保存');
+        await loadSyncPanel();
+      } catch (err) {
+        showToast('保存失败: ' + err.message, 'error');
+      }
+    });
+
+    // 上传
+    $('#btnSyncUpload').addEventListener('click', async () => {
+      const config = getSyncConfigFromForm();
+      if (!config.host) {
+        showToast('请先配置并保存 WebDAV', 'error');
+        return;
+      }
+      
+      if (!confirm('确定要上传到云端吗？这将覆盖云端的数据。')) return;
+      
+      $('#syncProgress').style.display = 'block';
+      $('#syncProgressText').textContent = '上传中...';
+      $('#syncProgressFill').style.width = '0%';
+      
+      try {
+        const result = await window.ClawBoard.syncToWebDAV(config);
+        if (result.success) {
+          $('#syncProgressFill').style.width = '100%';
+          $('#syncProgressText').textContent = `上传完成！${result.recordCount} 条记录已同步`;
+          showToast(`上传成功！${result.recordCount} 条记录`);
+          await loadSyncPanel();
+        } else {
+          showToast(`上传失败: ${result.error || result.status}`, 'error');
+          $('#syncProgress').style.display = 'none';
+        }
+      } catch (err) {
+        showToast('上传失败: ' + err.message, 'error');
+        $('#syncProgress').style.display = 'none';
+      }
+    });
+
+    // 下载
+    $('#btnSyncDownload').addEventListener('click', async () => {
+      const config = getSyncConfigFromForm();
+      if (!config.host) {
+        showToast('请先配置并保存 WebDAV', 'error');
+        return;
+      }
+      
+      if (!confirm('确定要从云端下载吗？这将导入云端数据到本地。')) return;
+      
+      $('#syncProgress').style.display = 'block';
+      $('#syncProgressText').textContent = '下载中...';
+      $('#syncProgressFill').style.width = '0%';
+      
+      try {
+        const result = await window.ClawBoard.syncFromWebDAV(config);
+        if (result.success) {
+          $('#syncProgressFill').style.width = '100%';
+          $('#syncProgressText').textContent = `下载完成！导入 ${result.imported} 条记录`;
+          showToast(`下载成功！导入 ${result.imported} 条记录`);
+          await loadSyncPanel();
+        } else {
+          showToast(`下载失败: ${result.error || result.status}`, 'error');
+          $('#syncProgress').style.display = 'none';
+        }
+      } catch (err) {
+        showToast('下载失败: ' + err.message, 'error');
+        $('#syncProgress').style.display = 'none';
+      }
+    });
+
+    function getSyncConfigFromForm() {
+      const serverUrl = $('#syncServer').value.trim();
+      let host = serverUrl;
+      let protocol = 'https';
+      
+      // 解析 URL
+      if (serverUrl.startsWith('http://')) {
+        protocol = 'http';
+        host = serverUrl.replace('http://', '').split('/')[0];
+      } else if (serverUrl.startsWith('https://')) {
+        host = serverUrl.replace('https://', '').split('/')[0];
+      }
+      
+      const port = host.includes(':') ? parseInt(host.split(':')[1]) : (protocol === 'https' ? 443 : 80);
+      if (host.includes(':')) host = host.split(':')[0];
+      
+      return {
+        protocol,
+        host,
+        port,
+        path: $('#syncPath').value.trim() || '/',
+        username: $('#syncUsername').value.trim(),
+        password: $('#syncPassword').value,
+        encrypt: $('#syncEncrypt').checked,
+        encryptionKey: $('#syncEncryptKey').value,
+        onlyFavorites: $('#syncOnlyFavorites').checked,
+      };
+    }
+
+    async function loadSyncPanel() {
+      try {
+        // 加载同步元数据
+        const metadata = await window.ClawBoard.getSyncMetadata();
+        
+        // 更新状态显示
+        if (metadata.config && metadata.config.host) {
+          $('#syncServer').value = `${metadata.config.protocol}://${metadata.config.host}:${metadata.config.port}`;
+          $('#syncPath').value = metadata.config.path || '/';
+          $('#syncUsername').value = metadata.config.username || '';
+          $('#syncPassword').value = metadata.config.password || '';
+          $('#syncEncrypt').checked = metadata.config.encrypt !== false;
+          $('#syncOnlyFavorites').checked = metadata.config.onlyFavorites || false;
+          $('#syncEncryptKeyItem').style.display = metadata.config.encrypt ? 'block' : 'none';
+          $('#syncEncryptKey').value = metadata.config.encryptionKey || '';
+          
+          $('#syncStatusText').textContent = '已配置';
+          $('#syncStatusDetail').textContent = metadata.lastSyncTime 
+            ? `上次同步: ${formatTime(metadata.lastSyncTime)}`
+            : '从未同步';
+          $('#syncStatusIcon').textContent = '☁️';
+          
+          $('#btnSyncUpload').disabled = false;
+          $('#btnSyncDownload').disabled = false;
+        } else {
+          $('#syncStatusText').textContent = '未配置';
+          $('#syncStatusDetail').textContent = '点击配置 WebDAV 同步';
+          $('#btnSyncUpload').disabled = true;
+          $('#btnSyncDownload').disabled = true;
+        }
+        
+        // 加载同步统计
+        const stats = await window.ClawBoard.getSyncStats();
+        if (stats) {
+          $('#syncStats').style.display = 'block';
+          $('#syncTotalRecords').textContent = stats.total;
+          $('#syncSyncedRecords').textContent = stats.synced;
+          $('#syncPendingRecords').textContent = stats.pending;
+        }
+      } catch (err) {
+        console.error('加载同步面板失败:', err);
+      }
+    }
+
     // 统计导出按钮
     const originalLoadDetailedStats = loadDetailedStats;
     window.loadDetailedStats = async function() {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -39,6 +39,7 @@
       </span>
       <button class="icon-btn" id="btnSettings" title="设置">⚙️</button>
       <button class="icon-btn" id="btnPinnedManager" title="置顶管理">📌</button>
+      <button class="icon-btn" id="btnCloudSync" title="云端同步">☁️</button>
     </div>
   </header>
 
@@ -260,6 +261,112 @@
         <div class="pinned-list" id="pinnedList">
           <div class="loading" id="pinnedLoading">
             <div class="spinner"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 云端同步面板 v0.28.0 -->
+  <div class="settings-overlay" id="cloudSyncOverlay">
+    <div class="settings-panel" style="width:500px">
+      <div class="settings-header">
+        <h2>☁️ 云端同步</h2>
+        <button class="detail-close" id="btnCloseCloudSync">×</button>
+      </div>
+      <div class="settings-body">
+        <!-- 同步状态 -->
+        <div class="sync-status" id="syncStatus">
+          <div class="sync-status-icon">☁️</div>
+          <div class="sync-status-info">
+            <div class="sync-status-text" id="syncStatusText">未配置</div>
+            <div class="sync-status-detail" id="syncStatusDetail">点击配置 WebDAV 同步</div>
+          </div>
+        </div>
+        
+        <!-- 同步进度 -->
+        <div class="sync-progress" id="syncProgress" style="display:none">
+          <div class="sync-progress-bar">
+            <div class="sync-progress-fill" id="syncProgressFill"></div>
+          </div>
+          <div class="sync-progress-text" id="syncProgressText">同步中...</div>
+        </div>
+
+        <!-- WebDAV 配置 -->
+        <div class="sync-config">
+          <h3>WebDAV 配置</h3>
+          <div class="sync-config-form">
+            <div class="setting-item">
+              <label>服务器地址</label>
+              <input type="text" id="syncServer" placeholder="https://dav.example.com" value="">
+            </div>
+            <div class="setting-item">
+              <label>同步路径</label>
+              <input type="text" id="syncPath" placeholder="/dav/clipboard" value="/">
+            </div>
+            <div class="setting-item">
+              <label>用户名</label>
+              <input type="text" id="syncUsername" placeholder="用户名" value="">
+            </div>
+            <div class="setting-item">
+              <label>密码</label>
+              <input type="password" id="syncPassword" placeholder="密码" value="">
+            </div>
+            <div class="setting-item">
+              <label>
+                <input type="checkbox" id="syncEncrypt" checked>
+                端到端加密
+              </label>
+              <small style="color:var(--muted);margin-left:1.5rem">启用后需要输入加密密钥</small>
+            </div>
+            <div class="setting-item" id="syncEncryptKeyItem" style="display:none">
+              <label>加密密钥</label>
+              <input type="password" id="syncEncryptKey" placeholder="设置加密密钥（用于保护云端数据）" value="">
+            </div>
+            <div class="setting-item">
+              <label>
+                <input type="checkbox" id="syncOnlyFavorites">
+                仅同步收藏
+              </label>
+            </div>
+          </div>
+          <div class="sync-actions">
+            <button class="sync-btn" id="btnTestConnection">🔗 测试连接</button>
+            <button class="sync-btn primary" id="btnSaveSyncConfig">💾 保存配置</button>
+          </div>
+        </div>
+
+        <!-- 同步操作 -->
+        <div class="sync-operations">
+          <h3>同步操作</h3>
+          <div class="sync-op-buttons">
+            <button class="sync-op-btn" id="btnSyncUpload" disabled>
+              <span class="op-icon">⬆️</span>
+              <span class="op-text">上传到云端</span>
+            </button>
+            <button class="sync-op-btn" id="btnSyncDownload" disabled>
+              <span class="op-icon">⬇️</span>
+              <span class="op-text">从云端下载</span>
+            </button>
+          </div>
+        </div>
+
+        <!-- 同步统计 -->
+        <div class="sync-stats" id="syncStats" style="display:none">
+          <h3>📊 同步统计</h3>
+          <div class="sync-stats-grid">
+            <div class="sync-stat-item">
+              <span class="sync-stat-value" id="syncTotalRecords">0</span>
+              <span class="sync-stat-label">总记录</span>
+            </div>
+            <div class="sync-stat-item">
+              <span class="sync-stat-value" id="syncSyncedRecords">0</span>
+              <span class="sync-stat-label">已同步</span>
+            </div>
+            <div class="sync-stat-item">
+              <span class="sync-stat-value" id="syncPendingRecords">0</span>
+              <span class="sync-stat-label">待同步</span>
+            </div>
           </div>
         </div>
       </div>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -94,3 +94,35 @@
 .record-btn{width:32px;height:32px;border-radius:6px;background:var(--surface2);border:none;color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all 0.2s;font-size:0.9rem}
 .record-btn:hover{background:var(--accent-bg);color:var(--accent)}
 .record-btn.danger:hover{background:rgba(239,68,68,0.1);color:#ef4444}
+
+/* v0.28.0: 云端同步样式 */
+.sync-status{display:flex;align-items:center;gap:1rem;padding:1rem;background:var(--surface);border:1px solid var(--border);border-radius:12px;margin-bottom:1rem}
+.sync-status-icon{font-size:2rem}
+.sync-status-info{flex:1}
+.sync-status-text{font-size:1.1rem;font-weight:600;color:var(--text)}
+.sync-status-detail{font-size:0.85rem;color:var(--muted)}
+.sync-progress{margin-bottom:1rem}
+.sync-progress-bar{height:8px;background:var(--surface2);border-radius:4px;overflow:hidden}
+.sync-progress-fill{height:100%;background:var(--accent);width:0%;transition:width 0.3s ease}
+.sync-progress-text{font-size:0.85rem;color:var(--muted);margin-top:0.5rem}
+.sync-config{margin-bottom:1.5rem}
+.sync-config h3{font-size:1rem;margin-bottom:0.8rem}
+.sync-config-form{display:flex;flex-direction:column;gap:0.8rem}
+.sync-actions{display:flex;gap:0.5rem;margin-top:1rem}
+.sync-btn{padding:0.6rem 1rem;border-radius:8px;font-size:0.9rem;background:var(--surface);color:var(--text);border:1px solid var(--border);transition:all 0.2s;flex:1}
+.sync-btn:hover{border-color:var(--accent);background:var(--accent-bg);color:var(--accent)}
+.sync-btn.primary{background:var(--accent);color:#fff;border-color:var(--accent)}
+.sync-btn.primary:hover{background:var(--accent-hover)}
+.sync-operations{margin-bottom:1.5rem}
+.sync-operations h3{font-size:1rem;margin-bottom:0.8rem}
+.sync-op-buttons{display:flex;gap:0.8rem}
+.sync-op-btn{display:flex;flex-direction:column;align-items:center;gap:0.5rem;padding:1.2rem;background:var(--surface);border:1px solid var(--border);border-radius:12px;cursor:pointer;transition:all 0.2s;flex:1}
+.sync-op-btn:hover:not(:disabled){border-color:var(--accent);background:var(--accent-bg)}
+.sync-op-btn:disabled{opacity:0.5;cursor:not-allowed}
+.sync-op-btn .op-icon{font-size:1.5rem}
+.sync-op-btn .op-text{font-size:0.9rem;color:var(--text)}
+.sync-stats h3{font-size:1rem;margin-bottom:0.8rem}
+.sync-stats-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:0.8rem}
+.sync-stat-item{background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:0.8rem;text-align:center}
+.sync-stat-value{font-size:1.25rem;font-weight:700;color:var(--text);display:block}
+.sync-stat-label{font-size:0.75rem;color:var(--muted)}


### PR DESCRIPTION
## v0.28.0: 云端同步功能

为 ClawBoard 添加云端同步能力，支持 WebDAV 协议对接主流云存储服务。

### 新增功能

- **WebDAV 同步**：支持 NextCloud、坚果云等支持 WebDAV 的云存储服务
- **端到端加密**：使用 AES-256-GCM 加密数据后再上传，保护隐私
- **同步状态指示**：显示配置状态和上次同步时间
- **手动同步**：支持手动上传/下载同步
- **仅同步收藏**：可设置仅同步置顶的剪贴板记录
- **同步统计**：显示总记录数、已同步数、待同步数

### 技术实现

- **数据库**：exportForSync、importFromSync、getSyncMetadata、getSyncStats 等方法
- **主进程**：WebDAV 连接测试、上传、下载 IPC 处理器
- **前端**：同步配置表单、上传/下载按钮、进度显示

### 界面入口

- 标题栏 ☁️ 按钮打开云端同步面板

### Issue

Closes #61