### PR TITLE
feat: 剪贴板条目备注功能 v0.30.0

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -128,6 +128,13 @@ class Database {
       // 列已存在，忽略
     }
 
+    // 添加备注列（如果不存在）- v0.30.0 条目备注功能
+    try {
+      this.db.run(`ALTER TABLE records ADD COLUMN note TEXT DEFAULT ''`);
+    } catch (e) {
+      // 列已存在，忽略
+    }
+
     // 创建分组表
     this.db.run(`
       CREATE TABLE IF NOT EXISTS groups (
@@ -417,8 +424,8 @@ class Database {
     }
 
     if (search) {
-      sql += ' AND (content LIKE ? OR summary LIKE ? OR ocr_text LIKE ?)';
-      params.push(`%${search}%`, `%${search}%`, `%${search}%`);
+      sql += ' AND (content LIKE ? OR summary LIKE ? OR ocr_text LIKE ? OR note LIKE ?)';
+      params.push(`%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`);
       // 加密记录不参与搜索
       sql += ' AND encrypted = 0';
     }
@@ -671,6 +678,13 @@ class Database {
   // 切换收藏
   toggleFavorite(id) {
     this.db.run(`UPDATE records SET favorite = NOT favorite, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, [id]);
+    this._save();
+    return true;
+  }
+
+  // 更新备注
+  updateNote(id, note) {
+    this.db.run(`UPDATE records SET note = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?`, [note, id]);
     this._save();
     return true;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -201,6 +201,16 @@ function setupIPC() {
     }
   });
 
+  // 更新备注
+  ipcMain.handle('update-note', async (event, { id, note }) => {
+    try {
+      return db.updateNote(id, note);
+    } catch (err) {
+      log.error('update-note error:', err);
+      return false;
+    }
+  });
+
   // 删除记录
   ipcMain.handle('delete-record', async (event, id) => {
     try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -11,6 +11,7 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   getRecords: (options) => ipcRenderer.invoke('get-records', options),
   getRecord: (id) => ipcRenderer.invoke('get-record', id),
   toggleFavorite: (id) => ipcRenderer.invoke('toggle-favorite', id),
+  updateNote: (id, note) => ipcRenderer.invoke('update-note', { id, note }),
   deleteRecord: (id) => ipcRenderer.invoke('delete-record', id),
   clearHistory: () => ipcRenderer.invoke('clear-history'),
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -580,6 +580,27 @@
       $('#newTagInput').focus();
     });
 
+    // v0.30.0: 备注按钮
+    $('#btnNote').addEventListener('click', () => {
+      const section = $('#detailNoteSection');
+      const wasVisible = section.style.display !== 'none';
+      if (wasVisible) {
+        // 保存并关闭
+        saveDetailNote();
+        section.style.display = 'none';
+      } else {
+        section.style.display = 'block';
+        $('#detailNoteInput').focus();
+      }
+    });
+
+    // 备注输入框失焦自动保存
+    $('#detailNoteInput').addEventListener('blur', () => {
+      if ($('#detailNoteSection').style.display !== 'none') {
+        saveDetailNote();
+      }
+    });
+
     // v0.17.0: OCR 复制按钮
     $('#btnCopyOCR').addEventListener('click', handleCopyOCR);
 
@@ -1691,6 +1712,12 @@
       }
     } catch (e) {}
 
+    // 备注
+    const noteText = record.note || '';
+    const noteHtml = noteText
+      ? `<div class="record-note" title="${escapeHtml(noteText)}">📝 ${escapeHtml(noteText.length > 40 ? noteText.substring(0, 38) + '...' : noteText)}</div>`
+      : '';
+
     // 多选模式下显示复选框
     const checkboxHtml = isMultiSelectMode
       ? `<span class="record-checkbox ${selectedIds.has(record.id) ? 'checked' : ''}">${selectedIds.has(record.id) ? '✓' : ''}</span>`
@@ -1705,9 +1732,13 @@
         <span class="record-fav" title="${record.favorite ? '取消收藏' : '收藏'}">
           ${record.favorite ? '★' : '☆'}
         </span>
+        <button class="record-note-btn ${noteText ? 'has-note' : ''}" data-id="${record.id}" title="${noteText ? '查看/编辑备注' : '添加备注'}">
+          📝
+        </button>
       </div>
       <div class="record-content ${record.type}">${formatContent(record)}</div>
       ${tagsHtml}
+      ${noteHtml}
     `;
 
     card.addEventListener('click', (e) => {
@@ -1717,6 +1748,13 @@
       } else {
         openDetailPanel(record);
       }
+    });
+
+    // 备注按钮 - 内联编辑
+    const noteBtn = card.querySelector('.record-note-btn');
+    noteBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      showNoteEditor(record, noteBtn);
     });
 
     // 拖拽排序
@@ -1848,6 +1886,14 @@
     const btnFav = $('#btnFavorite');
     btnFav.textContent = record.favorite ? '☆ 取消收藏' : '☆ 收藏';
 
+    // v0.30.0: 显示备注
+    const noteSection = $('#detailNoteSection');
+    const noteInput = $('#detailNoteInput');
+    noteInput.value = record.note || '';
+    if (record.note) {
+      noteSection.style.display = 'block';
+    }
+
     // 显示/隐藏预览模式按钮（仅文字类型支持 Markdown 预览）
     const previewModes = $('#previewModes');
     if (record.type === 'text' && isMarkdown(record.content)) {
@@ -1939,6 +1985,10 @@
   }
 
   function closeDetailPanel() {
+    // v0.30.0: 保存备注
+    if ($('#detailNoteSection').style.display !== 'none') {
+      saveDetailNote();
+    }
     detailPanel.classList.remove('open');
     selectedRecord = null;
   }
@@ -2573,6 +2623,100 @@
       clearTimeout(timer);
       timer = setTimeout(() => fn.apply(this, args), delay);
     };
+  }
+
+  function saveDetailNote() {
+    if (!selectedRecord) return;
+    const note = $('#detailNoteInput').value.trim();
+    window.ClawBoard.updateNote(selectedRecord.id, note);
+    selectedRecord.note = note;
+    // 更新卡片上的备注显示
+    const card = document.querySelector(`.record-card[data-id="${selectedRecord.id}"]`);
+    if (card) {
+      const btn = card.querySelector('.record-note-btn');
+      const noteEl = card.querySelector('.record-note');
+      if (btn) {
+        btn.classList.toggle('has-note', !!note);
+        btn.title = note ? '查看/编辑备注' : '添加备注';
+      }
+      if (note) {
+        const contentDiv = card.querySelector('.record-content');
+        if (noteEl) {
+          noteEl.textContent = '📝 ' + note;
+        } else {
+          const newNote = document.createElement('div');
+          newNote.className = 'record-note';
+          newNote.textContent = '📝 ' + note;
+          contentDiv.after(newNote);
+        }
+      } else if (noteEl) {
+        noteEl.remove();
+      }
+    }
+  }
+
+  function showNoteEditor(record, btn) {
+    // 如果已经有一个编辑框在显示，先移除
+    const existing = document.querySelector('.note-editor-popup');
+    if (existing) existing.remove();
+
+    const popup = document.createElement('div');
+    popup.className = 'note-editor-popup';
+    popup.innerHTML = `
+      <textarea class="note-textarea" placeholder="添加备注..." rows="3">${escapeHtml(record.note || '')}</textarea>
+      <div class="note-editor-actions">
+        <button class="btn-note-save">保存</button>
+        <button class="btn-note-cancel">取消</button>
+      </div>
+    `;
+
+    btn.parentNode.insertBefore(popup, btn.nextSibling);
+
+    const textarea = popup.querySelector('.note-textarea');
+    textarea.focus();
+    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
+
+    popup.querySelector('.btn-note-save').addEventListener('click', async () => {
+      const note = textarea.value.trim();
+      await window.ClawBoard.updateNote(record.id, note);
+      // 更新卡片 UI
+      const card = btn.closest('.record-card');
+      if (card) {
+        const noteEl = card.querySelector('.record-note');
+        if (note) {
+          if (noteEl) {
+            noteEl.textContent = '📝 ' + note;
+            noteEl.title = note;
+          } else {
+            const contentDiv = card.querySelector('.record-content');
+            const newNote = document.createElement('div');
+            newNote.className = 'record-note';
+            newNote.textContent = '📝 ' + note;
+            newNote.title = note;
+            contentDiv.after(newNote);
+          }
+        } else if (noteEl) {
+          noteEl.remove();
+        }
+        btn.classList.toggle('has-note', !!note);
+        btn.title = note ? '查看/编辑备注' : '添加备注';
+      }
+      popup.remove();
+      showToast(note ? '✅ 备注已保存' : '✅ 备注已清除', 'success');
+    });
+
+    popup.querySelector('.btn-note-cancel').addEventListener('click', () => {
+      popup.remove();
+    });
+
+    // 点击外部关闭
+    const handleOutside = (e) => {
+      if (!popup.contains(e.target) && e.target !== btn) {
+        popup.remove();
+        document.removeEventListener('click', handleOutside);
+      }
+    };
+    setTimeout(() => document.addEventListener('click', handleOutside), 50);
   }
 
   function showToast(message, type = '') {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -117,6 +117,7 @@
         <button class="detail-btn" id="btnCopy" title="复制">📋 复制</button>
         <button class="detail-btn" id="btnFavorite" title="收藏">☆ 收藏</button>
         <button class="detail-btn" id="btnAddTag" title="添加标签">🏷️ 标签</button>
+        <button class="detail-btn" id="btnNote" title="备注">📝 备注</button>
         <button class="detail-btn" id="btnEncrypt" title="加密" style="display:none">🔒 加密</button>
         <button class="detail-btn" id="btnDecrypt" title="解密" style="display:none">🔓 查看</button>
         <button class="detail-btn danger" id="btnDelete" title="删除">🗑️ 删除</button>
@@ -139,6 +140,10 @@
     </div>
     <div class="detail-footer" id="detailFooter">
       <!-- AI 摘要等 -->
+    </div>
+    <div class="detail-note-section" id="detailNoteSection" style="display:none">
+      <div class="detail-note-label">📝 备注</div>
+      <textarea class="detail-note-input" id="detailNoteInput" placeholder="添加备注..."></textarea>
     </div>
   </div>
 

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -40,7 +40,7 @@ input{font-family:inherit;outline:none}
 
 .main{position:fixed;top:108px;left:0;right:0;bottom:0;padding:1rem 1.5rem;overflow-y:auto;transition:right 0.3s}
 
-.record-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:1rem 1.2rem;margin-bottom:0.8rem;cursor:pointer;transition:all 0.2s;position:relative;overflow:hidden}
+.record-card{background:var(--surface);border:1px solid var(--border);border-radius:12px;padding:1rem 1.2rem;margin-bottom:0.8rem;cursor:pointer;transition:all 0.2s;position:relative;overflow:visible}
 .record-card::before{content:'';position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--accent);opacity:0;transition:opacity 0.2s}
 .record-card:hover{border-color:rgba(249,115,22,0.3);transform:translateX(2px)}
 .record-card:hover::before{opacity:1}
@@ -258,6 +258,16 @@ input{font-family:inherit;outline:none}
 .btn-sm{padding:0.3rem 0.6rem;font-size:0.8rem}
 .record-tags{display:flex;gap:0.3rem;flex-wrap:wrap;margin-top:0.3rem}
 .record-tag{padding:0.1rem 0.4rem;background:var(--accent-bg);color:var(--accent);border-radius:4px;font-size:0.7rem}
+.record-note-btn{background:none;border:none;cursor:pointer;opacity:0.4;font-size:0.85rem;padding:0;margin-left:0.2rem;transition:opacity 0.2s}
+.record-note-btn:hover,.record-note-btn.has-note{opacity:1}
+.record-note{font-size:0.75rem;color:var(--muted);margin-top:0.3rem;display:flex;align-items:flex-start;gap:0.3rem}
+.record-note::before{content:'📝';flex-shrink:0}
+.note-editor-popup{position:absolute;z-index:100;background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:0.6rem;min-width:250px;max-width:350px;box-shadow:0 4px 16px rgba(0,0,0,0.3)}
+.note-textarea{width:100%;resize:vertical;font-size:0.85rem;padding:0.4rem;border:1px solid var(--border);border-radius:6px;background:var(--bg);color:var(--text);font-family:inherit;min-height:60px}
+.note-editor-actions{display:flex;gap:0.4rem;margin-top:0.4rem;justify-content:flex-end}
+.btn-note-save,.btn-note-cancel{padding:0.3rem 0.8rem;border-radius:6px;font-size:0.8rem;cursor:pointer;border:none}
+.btn-note-save{background:var(--accent);color:#fff}
+.btn-note-cancel{background:var(--surface);color:var(--text);border:1px solid var(--border)}
 .tags-presets{display:flex;flex-wrap:wrap;gap:0.4rem;margin-top:0.5rem}
 .tag-preset{padding:0.3rem 0.6rem;background:var(--surface);border:1px solid var(--border);border-radius:6px;font-size:0.8rem;cursor:pointer;transition:all 0.2s}
 .tag-preset:hover{border-color:var(--accent);background:var(--accent-bg)}
@@ -275,6 +285,12 @@ input{font-family:inherit;outline:none}
 .ocr-copy-btn{margin-top:0.8rem;padding:0.4rem 0.8rem;border-radius:6px;background:var(--accent-bg);color:var(--accent);font-size:0.8rem;transition:all 0.2s;border:1px solid transparent}
 .ocr-copy-btn:hover{background:var(--accent);color:#fff}
 .ocr-badge{font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:3px;background:rgba(59,130,246,0.15);color:#93c5fd;margin-left:0.3rem}
+
+/* v0.30.0: 详情面板备注 */
+.detail-note-section{padding:0.8rem 1.5rem;border-top:1px solid var(--border);background:var(--surface2)}
+.detail-note-label{font-size:0.8rem;color:var(--muted);margin-bottom:0.4rem;font-weight:600}
+.detail-note-input{width:100%;min-height:60px;resize:vertical;padding:0.5rem;border:1px solid var(--border);border-radius:8px;background:var(--surface);color:var(--text);font-family:inherit;font-size:0.85rem}
+.detail-note-input:focus{outline:none;border-color:var(--accent)}
 
 /* v0.23.0: 内容合并样式 */
 .merge-separator-options{display:flex;gap:0.5rem;flex-wrap:wrap}


### PR DESCRIPTION
## 功能说明
- 每条剪贴板条目支持添加/编辑自定义备注
- 卡片列表中显示备注图标，有备注时高亮显示
- 点击图标弹出内联编辑器快速编辑
- 详情面板支持备注编辑（底部备注区）
- 搜索时同时搜索备注内容

## 实现细节
- database.js: 新增 note 列和 updateNote() 方法
- main.js: IPC handler update-note
- preload.js: 暴露 updateNote API
- app.js: 卡片显示备注图标、内联编辑器、详情面板备注区
- styles.css: 备注相关样式