### PR TITLE
feat: 剪贴板条目自动过期清理 v0.31.0

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -1725,4 +1725,85 @@ class Database {
   }
 }
 
-module.exports = Database;
+
+  // v0.31.0: 自动过期清理
+  getAutoExpirySettings() {
+    try {
+      const get = (key, def) => {
+        const row = this.db.exec(\SELECT value FROM settings WHERE key = ''\);
+        return row.length > 0 && row[0].values.length > 0 ? row[0].values[0][0] : def;
+      };
+      return {
+        enabled: get('expiry_enabled', 'false') === 'true',
+        days: parseInt(get('expiry_days', '30')) || 30,
+        keepFavorites: get('expiry_keep_favorites', 'true') === 'true',
+      };
+    } catch (e) {
+      console.error('获取自动过期设置失败:', e);
+      return { enabled: false, days: 30, keepFavorites: true };
+    }
+  }
+
+  saveAutoExpirySettings(settings) {
+    try {
+      const updates = [
+        ['expiry_enabled', settings.enabled ? 'true' : 'false'],
+        ['expiry_days', String(settings.days || 30)],
+        ['expiry_keep_favorites', settings.keepFavorites ? 'true' : 'false'],
+      ];
+      for (const [key, value] of updates) {
+        this.db.run(\INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)\, [key, value]);
+      }
+      return true;
+    } catch (e) {
+      console.error('保存自动过期设置失败:', e);
+      return false;
+    }
+  }
+
+  cleanExpiredItems() {
+    try {
+      const settings = this.getAutoExpirySettings();
+      if (!settings.enabled || settings.days <= 0) return 0;
+      const cutoffDate = new Date(Date.now() - settings.days * 86400000).toISOString();
+      let query;
+      if (settings.keepFavorites) {
+        query = \DELETE FROM clipboard_history WHERE created_at < '' AND favorite = 0\;
+      } else {
+        query = \DELETE FROM clipboard_history WHERE created_at < ''\;
+      }
+      this.db.run(query);
+      const result = this.db.exec('SELECT changes() as count');
+      return result.length > 0 && result[0].values.length > 0 ? result[0].values[0][0] : 0;
+    } catch (e) {
+      console.error('清理过期条目失败:', e);
+      return 0;
+    }
+  }
+
+  getExpiryStats() {
+    try {
+      const settings = this.getAutoExpirySettings();
+      if (!settings.enabled || settings.days <= 0) return { total: 0, expired: 0, protected: 0 };
+      const cutoffDate = new Date(Date.now() - settings.days * 86400000).toISOString();
+      const getTotal = () => {
+        const r = this.db.exec(\SELECT COUNT(*) FROM clipboard_history WHERE created_at < ''\);
+        return r.length > 0 && r[0].values.length > 0 ? r[0].values[0][0] : 0;
+      };
+      const getExpired = () => {
+        const q = settings.keepFavorites
+          ? \SELECT COUNT(*) FROM clipboard_history WHERE created_at < '' AND favorite = 0          : \SELECT COUNT(*) FROM clipboard_history WHERE created_at < ''\;
+        const r = this.db.exec(q);
+        return r.length > 0 && r[0].values.length > 0 ? r[0].values[0][0] : 0;
+      };
+      const getProtected = () => {
+        const r = this.db.exec(\SELECT COUNT(*) FROM clipboard_history WHERE created_at < '' AND favorite = 1\);
+        return r.length > 0 && r[0].values.length > 0 ? r[0].values[0][0] : 0;
+      };
+      return { total: getTotal(), expired: getExpired(), protected: getProtected() };
+    } catch (e) {
+      console.error('获取过期统计失败:', e);
+      return { total: 0, expired: 0, protected: 0 };
+    }
+  }
+\nmodule.exports = Database;

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,8 @@ let db = null;
 let clipboardWatcher = null;
 let ocrService = null; // v0.17.0 OCR服务实例
 let smartPaste = null; // v0.31.0 智能粘贴实例
-let ignoreRules = null; // v0.31.0 忽略规则实例
+let ignoreRules = null; // v0.31.0
+let autoExpiryTimer = null; // v0.31.0 忽略规则实例
 
 // v0.29.0: 通知与声音设置
 let notificationSettings = {
@@ -1048,6 +1049,9 @@ app.whenReady().then(async () => {
   // v0.29.0: 将通知函数暴露给全局，供剪贴板模块调用
   global.showClipboardNotification = showClipboardNotification;
 
+  // v0.31.0: 启动自动过期清理定时器
+  startAutoExpiryTimer();
+
   // 创建窗口和托盘
   createWindow();
   createTray();
@@ -1131,6 +1135,32 @@ function playNotificationSound() {
 }
 
 // v0.29.0: 显示剪贴板捕获通知
+
+// v0.31.0: 自动过期清理定时器
+function startAutoExpiryTimer() {
+  if (autoExpiryTimer) clearInterval(autoExpiryTimer);
+  if (!db) return;
+  const settings = db.getAutoExpirySettings();
+  if (!settings.enabled) return;
+  autoExpiryTimer = setInterval(() => {
+    try {
+      const count = db.cleanExpiredItems();
+      if (count > 0) {
+        log.info('自动过期清理: 删除了 ' + count + ' 条过期记录');
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          mainWindow.webContents.send('expiry-cleanup', { count });
+        }
+      }
+    } catch (err) {
+      log.error('自动过期清理失败:', err);
+    }
+  }, 3600000);
+  const count = db.cleanExpiredItems();
+  if (count > 0) {
+    log.info('启动时自动过期清理: 删除了 ' + count + ' 条过期记录');
+  }
+}
+
 function showClipboardNotification(record) {
   if (!notificationSettings.enabled) return;
   
@@ -1444,5 +1474,45 @@ ipcMain.handle('test-ignore-rules', async (_, { content, metadata }) => {
   } catch (err) {
     log.error('test-ignore-rules error:', err);
     return { shouldIgnore: false, reason: '' };
+  }
+});\n
+// ==================== v0.31.0: 自动过期清理 ====================
+
+ipcMain.handle('get-auto-expiry-settings', async () => {
+  try {
+    return db.getAutoExpirySettings();
+  } catch (err) {
+    log.error('get-auto-expiry-settings error:', err);
+    return { enabled: false, days: 30, keepFavorites: true };
+  }
+});
+
+ipcMain.handle('save-auto-expiry-settings', async (_, settings) => {
+  try {
+    db.saveAutoExpirySettings(settings);
+    startAutoExpiryTimer();
+    return { success: true };
+  } catch (err) {
+    log.error('save-auto-expiry-settings error:', err);
+    return { success: false, message: err.message };
+  }
+});
+
+ipcMain.handle('get-expiry-stats', async () => {
+  try {
+    return db.getExpiryStats();
+  } catch (err) {
+    log.error('get-expiry-stats error:', err);
+    return { total: 0, expired: 0, protected: 0 };
+  }
+});
+
+ipcMain.handle('clean-expired-items', async () => {
+  try {
+    const count = db.cleanExpiredItems();
+    return { success: true, count };
+  } catch (err) {
+    log.error('clean-expired-items error:', err);
+    return { success: false, count: 0, message: err.message };
   }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -98,6 +98,12 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   getNotificationSettings: () => ipcRenderer.invoke('get-notification-settings'),
   saveNotificationSettings: (settings) => ipcRenderer.invoke('save-notification-settings', settings),
   showClipboardNotification: (data) => ipcRenderer.invoke('show-clipboard-notification', data),
+  // v0.31.0: 自动过期清理
+  getAutoExpirySettings: () => ipcRenderer.invoke('get-auto-expiry-settings'),
+  saveAutoExpirySettings: (settings) => ipcRenderer.invoke('save-auto-expiry-settings', settings),
+  getExpiryStats: () => ipcRenderer.invoke('get-expiry-stats'),
+  cleanExpiredItems: () => ipcRenderer.invoke('clean-expired-items'),
+  onExpiryCleanup: (callback) => ipcRenderer.on('expiry-cleanup', (_, data) => callback(data)),
 
   // v0.31.0: 智能粘贴
   getSmartPasteTypes: () => ipcRenderer.invoke('get-smart-paste-types'),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1451,6 +1451,17 @@
       } catch (e) {
         console.error('加载通知设置失败:', e);
       }
+
+      // v0.31.0: 加载自动过期设置
+      try {
+        const expirySettings = await window.ClawBoard.getAutoExpirySettings();
+        $('#settingExpiryEnabled').checked = expirySettings.enabled || false;
+        $('#settingExpiryDays').value = expirySettings.days || 30;
+        $('#settingExpiryKeepFavorites').checked = expirySettings.keepFavorites !== false;
+        loadExpiryStats();
+      } catch (e) {
+        console.error('加载自动过期设置失败:', e);
+      }
     } catch (err) {
       console.error('加载设置失败:', err);
     }
@@ -2488,6 +2499,13 @@
         largeTextThreshold: parseInt($('#settingNotificationLargeThreshold').value) || 1000,
       };
       await window.ClawBoard.updateNotificationSettings(notificationSettings);
+      // v0.31.0: 保存自动过期设置
+      const expirySettings = {
+        enabled: $('#settingExpiryEnabled').checked,
+        days: parseInt($('#settingExpiryDays').value) || 30,
+        keepFavorites: $('#settingExpiryKeepFavorites').checked,
+      };
+      await window.ClawBoard.saveAutoExpirySettings(expirySettings);
       // 更新全局快捷键
       await window.ClawBoard.updateShortcut(shortcuts.global);
       applyTheme(settings.theme);
@@ -2495,6 +2513,17 @@
       showToast('✅ 设置已保存', 'success');
     } catch (err) {
       showToast('❌ 保存失败', 'error');
+    }
+  }
+
+  // v0.31.0: 加载过期统计
+  async function loadExpiryStats() {
+    try {
+      const stats = await window.ClawBoard.getExpiryStats();
+      $('#expiryExpiredCount').textContent = stats.expired;
+      $('#expiryProtectedCount').textContent = stats.protected;
+    } catch (e) {
+      console.error('加载过期统计失败:', e);
     }
   }
 
@@ -2513,6 +2542,31 @@
 
   // v0.29.0: 测试通知按钮
   $('#btnTestNotification').addEventListener('click', handleTestNotification);
+
+  // v0.31.0: 立即清理过期条目
+  $('#btnCleanExpired').addEventListener('click', async () => {
+    try {
+      const result = await window.ClawBoard.cleanExpiredItems();
+      if (result.success) {
+        showToast('🗑️ 已清理 ' + result.count + ' 条过期记录', 'success');
+        loadExpiryStats();
+        loadRecords();
+      } else {
+        showToast('❌ 清理失败', 'error');
+      }
+    } catch (e) {
+      showToast('❌ 清理失败', 'error');
+    }
+  });
+
+  // v0.31.0: 监听过期清理事件
+  window.ClawBoard.onExpiryCleanup((data) => {
+    if (data.count > 0) {
+      showToast('🗑️ 自动清理了 ' + data.count + ' 条过期记录', 'info');
+      loadExpiryStats();
+      loadRecords();
+    }
+  });
 
   // ==================== 工具函数 ====================
   // 默认快捷键配置

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -390,6 +390,7 @@
         <button class="settings-tab active" data-tab="general">通用</button>
         <button class="settings-tab" data-tab="shortcuts">快捷键</button>
         <button class="settings-tab" data-tab="notifications">🔔 通知</button>
+        <button class="settings-tab" data-tab="expiry">🗑️ 数据管理</button>
       </div>
       <div class="settings-body">
         <!-- 通用设置 -->
@@ -499,6 +500,41 @@
           </div>
           <div class="setting-item" style="margin-top:1rem">
             <button class="btn-secondary" id="btnTestNotification">🔔 测试通知</button>
+          </div>
+        </div>
+        <!-- v0.31.0: 数据管理 -->
+        <div class="settings-tab-content" id="settingsExpiry" style="display:none">
+          <div class="setting-item">
+            <label>
+              <input type="checkbox" id="settingExpiryEnabled">
+              启用自动过期清理
+            </label>
+            <small style="color:var(--muted);margin-left:1.5rem;display:block;margin-top:0.25rem">自动删除超过设定天数的剪贴板记录</small>
+          </div>
+          <div class="setting-item">
+            <label>保留天数</label>
+            <select id="settingExpiryDays">
+              <option value="7">7 天</option>
+              <option value="14">14 天</option>
+              <option value="30" selected>30 天</option>
+              <option value="60">60 天</option>
+              <option value="90">90 天</option>
+              <option value="0">永不删除</option>
+            </select>
+          </div>
+          <div class="setting-item">
+            <label>
+              <input type="checkbox" id="settingExpiryKeepFavorites" checked>
+              收藏项例外
+            </label>
+            <small style="color:var(--muted);margin-left:1.5rem;display:block;margin-top:0.25rem">收藏的条目不会被自动清理</small>
+          </div>
+          <div class="expiry-stats" id="expiryStats" style="margin-top:1rem;padding:0.8rem;background:var(--surface2);border-radius:8px;font-size:0.85rem">
+            <div>📝 当前有过期条目：<strong id="expiryExpiredCount">-</strong> 条可清理</div>
+            <div style="margin-top:0.3rem;color:var(--muted)">⭐ 收藏保护：<strong id="expiryProtectedCount">-</strong> 条</div>
+          </div>
+          <div class="setting-item" style="margin-top:1rem">
+            <button class="btn-secondary" id="btnCleanExpired">🗑️ 立即清理过期条目</button>
           </div>
         </div>
       </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -303,3 +303,7 @@ input{font-family:inherit;outline:none}
 .record-card.merged-card{border-color:rgba(168,85,247,0.2);background:rgba(168,85,247,0.05)}
 .record-card.merged-card::before{background:#a855f7}
 .merged-badge{font-size:0.7rem;padding:0.1rem 0.4rem;border-radius:3px;background:rgba(168,85,247,0.15);color:#c4b5fd;margin-left:0.3rem}
+
+/* v0.31.0: 数据管理 - 自动过期 */
+.expiry-stats{padding:0.8rem 1rem;background:var(--surface2);border:1px solid var(--border);border-radius:8px;font-size:0.85rem;color:var(--text)}
+.expiry-stats strong{color:var(--accent)}


### PR DESCRIPTION
## 功能说明
- 设置面板新增「数据管理」标签页
- 支持启用/禁用自动过期清理
- 可配置保留天数（7/14/30/60/90天或永不删除）
- 收藏项可设为例外（不会被自动清理）
- 后台每小时自动检查并清理过期条目
- 显示当前过期统计（可清理数量、收藏保护数量）
- 「立即清理」按钮支持手动触发
- 清理时自动通知渲染进程刷新列表

## 实现细节
- database.js: 新增 getAutoExpirySettings/saveAutoExpirySettings/cleanExpiredItems/getExpiryStats
- main.js: IPC handlers + 定时器（每小时执行，启动时立即执行一次）
- preload.js: 暴露 4 个 API + 1 个事件监听
- index.html: 新增「数据管理」设置标签页
- app.js: 加载/保存设置、过期统计、手动清理、事件监听