### PR TITLE
feat: 暗色主题增强与系统主题跟随 v0.36.0

### DIFF
--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -1466,6 +1466,7 @@
       $('#settingAiSummary').checked = settings.aiSummary !== false;
       $('#settingStartWithSystem').checked = settings.startWithSystem || false;
       applyTheme(settings.theme || 'dark');
+      $('#settingTheme').value = settings.theme || 'dark';
 
       // 加载快捷键设置
       const shortcuts = settings.shortcuts || {};
@@ -1510,13 +1511,27 @@
     }
   }
 
+  let _themeMode = 'dark';
+  let _systemDarkQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
   function applyTheme(theme) {
-    if (theme === 'light') {
+    _themeMode = theme;
+    const effective = theme === 'system'
+      ? (_systemDarkQuery.matches ? 'dark' : 'light')
+      : theme;
+    if (effective === 'light') {
       document.documentElement.setAttribute('data-theme', 'light');
     } else {
       document.documentElement.removeAttribute('data-theme');
     }
   }
+
+  // 系统主题变化时自动切换
+  _systemDarkQuery.addEventListener('change', (e) => {
+    if (_themeMode === 'system') {
+      applyTheme('system');
+    }
+  });
 
   // ==================== 渲染 ====================
   function renderRecords() {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -432,6 +432,7 @@
             <select id="settingTheme">
               <option value="dark">深色</option>
               <option value="light">浅色</option>
+              <option value="system">跟随系统</option>
             </select>
           </div>
           <div class="setting-item">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,10 +1,10 @@
-:root{
-  --bg:#080b12;--surface:#0e1420;--surface2:#141928;--border:rgba(255,255,255,0.07);--accent:#f97316;--accent-light:#fb923c;--accent-bg:rgba(249,115,22,0.12);--blue:#3b82f6;--text:#f1f5f9;--muted:#64748b;--green:#22c55e;--red:#ef4444;--gradient:linear-gradient(135deg,#f97316,#ea580c);--shadow:0 8px 32px rgba(0,0,0,0.4)
+﻿:root{
+  --bg:#080b12;--surface:#0e1420;--surface2:#141928;--border:rgba(255,255,255,0.07);--accent:#f97316;--accent-light:#fb923c;--accent-bg:rgba(249,115,22,0.12);--blue:#3b82f6;--text:#f1f5f9;--muted:#64748b;--green:#22c55e;--red:#ef4444;--gradient:linear-gradient(135deg,#f97316,#ea580c);--shadow:0 8px 32px rgba(0,0,0,0.4);--header-bg:rgba(8,11,18,0.95);--tabs-bg:rgba(8,11,18,0.9);--hover-bg:rgba(255,255,255,0.05);--hover-bg2:rgba(255,255,255,0.1);--badge-bg:rgba(255,255,255,0.06);--scrollbar-hover:rgba(255,255,255,0.15);--btn-bg:rgba(255,255,255,0.06);--table-header-bg:rgba(255,255,255,0.05)
 }
 [data-theme="light"]{
-  --bg:#f8fafc;--surface:#ffffff;--surface2:#f1f5f9;--border:rgba(0,0,0,0.1);--accent:#ea580c;--accent-light:#f97316;--accent-bg:rgba(234,88,12,0.1);--text:#1e293b;--muted:#64748b;--shadow:0 8px 32px rgba(0,0,0,0.1)
+  --bg:#f8fafc;--surface:#ffffff;--surface2:#f1f5f9;--border:rgba(0,0,0,0.1);--accent:#ea580c;--accent-light:#f97316;--accent-bg:rgba(234,88,12,0.1);--text:#1e293b;--muted:#64748b;--shadow:0 8px 32px rgba(0,0,0,0.1);--header-bg:rgba(248,250,252,0.95);--tabs-bg:rgba(248,250,252,0.9);--hover-bg:rgba(0,0,0,0.04);--hover-bg2:rgba(0,0,0,0.08);--badge-bg:rgba(0,0,0,0.06);--scrollbar-hover:rgba(0,0,0,0.2);--btn-bg:rgba(0,0,0,0.06);--table-header-bg:rgba(0,0,0,0.04)
 }
-*{margin:0;padding:0;box-sizing:border-box}
+*{margin:0;padding:0;box-sizing:border-box;transition:background-color .3s,color .3s,border-color .3s}
 html,body{height:100%;overflow:hidden}
 body{background:var(--bg);color:var(--text);font-family:'Noto Sans SC',-apple-system,sans-serif;font-size:14px;line-height:1.6}
 body.drag-over{outline:3px dashed var(--accent);outline-offset:-3px}
@@ -14,9 +14,9 @@ input{font-family:inherit;outline:none}
 ::-webkit-scrollbar{width:5px}
 ::-webkit-scrollbar-track{background:transparent}
 ::-webkit-scrollbar-thumb{background:var(--border);border-radius:3px}
-::-webkit-scrollbar-thumb:hover{background:rgba(255,255,255,0.15)}
+::-webkit-scrollbar-thumb:hover{background:var(--scrollbar-hover)}
 
-.header{position:fixed;top:0;left:0;right:0;height:60px;padding:0 1.5rem;display:flex;align-items:center;gap:1.5rem;background:rgba(8,11,18,0.95);backdrop-filter:blur(20px);border-bottom:1px solid var(--border);z-index:50}
+.header{position:fixed;top:0;left:0;right:0;height:60px;padding:0 1.5rem;display:flex;align-items:center;gap:1.5rem;background:var(--header-bg,rgba(8,11,18,0.95));backdrop-filter:blur(20px);border-bottom:1px solid var(--border);z-index:50}
 .header-left{display:flex;align-items:center;gap:0.5rem;min-width:160px}
 .logo{font-size:1.8rem}
 .logo-text{font-size:1.2rem;font-weight:700;letter-spacing:-0.5px}
@@ -25,17 +25,17 @@ input{font-family:inherit;outline:none}
 .search-box input{width:100%;height:40px;padding:0 40px;border:1px solid var(--border);border-radius:10px;background:var(--surface);color:var(--text);font-size:0.9rem;transition:all 0.2s}
 .search-box input:focus{border-color:var(--accent);background:var(--surface2)}
 .search-box input::placeholder{color:var(--muted)}
-.search-clear{position:absolute;right:10px;top:50%;transform:translateY(-50%);width:24px;height:24px;border-radius:50%;background:rgba(255,255,255,0.1);color:var(--muted);font-size:1rem;display:none;align-items:center;justify-content:center;transition:all 0.2s}
-.search-clear:hover{background:rgba(255,255,255,0.2);color:var(--text)}
+.search-clear{position:absolute;right:10px;top:50%;transform:translateY(-50%);width:24px;height:24px;border-radius:50%;background:var(--hover-bg2);color:var(--muted);font-size:1rem;display:none;align-items:center;justify-content:center;transition:all 0.2s}
+.search-clear:hover{background:var(--hover-bg2);color:var(--text)}
 .search-clear.show{display:flex}
 .header-right{display:flex;align-items:center;gap:0.8rem;margin-left:auto}
 .stats-badge{display:flex;align-items:center;gap:0.4rem;padding:0.4rem 0.8rem;background:var(--surface);border-radius:8px;font-size:0.85rem;color:var(--muted)}
 .icon-btn{width:36px;height:36px;border-radius:8px;background:transparent;font-size:1.1rem;transition:all 0.2s;display:flex;align-items:center;justify-content:center}
 .icon-btn:hover{background:var(--surface)}
 
-.tabs{position:fixed;top:60px;left:0;right:0;height:48px;padding:0 1.5rem;display:flex;align-items:center;gap:0.3rem;background:rgba(8,11,18,0.9);backdrop-filter:blur(10px);border-bottom:1px solid var(--border);z-index:40;overflow-x:auto}
+.tabs{position:fixed;top:60px;left:0;right:0;height:48px;padding:0 1.5rem;display:flex;align-items:center;gap:0.3rem;background:var(--tabs-bg,rgba(8,11,18,0.9));backdrop-filter:blur(10px);border-bottom:1px solid var(--border);z-index:40;overflow-x:auto}
 .tab{padding:0.5rem 1rem;border-radius:8px;font-size:0.85rem;color:var(--muted);background:transparent;transition:all 0.2s;white-space:nowrap;font-weight:400}
-.tab:hover{color:var(--text);background:rgba(255,255,255,0.05)}
+.tab:hover{color:var(--text);background:var(--hover-bg)}
 .tab.active{color:var(--accent);background:var(--accent-bg);font-weight:600}
 
 .main{position:fixed;top:108px;left:0;right:0;bottom:0;padding:1rem 1.5rem;overflow-y:auto;transition:right 0.3s}
@@ -46,7 +46,7 @@ input{font-family:inherit;outline:none}
 .record-card:hover::before{opacity:1}
 .record-card.favorite{border-color:rgba(249,115,22,0.2);background:rgba(249,115,22,0.05)}
 .record-header{display:flex;align-items:center;gap:0.6rem;margin-bottom:0.5rem}
-.record-type{font-size:0.75rem;padding:0.2rem 0.5rem;border-radius:4px;font-weight:500;background:rgba(255,255,255,0.06);color:var(--muted)}
+.record-type{font-size:0.75rem;padding:0.2rem 0.5rem;border-radius:4px;font-weight:500;background:var(--badge-bg);color:var(--muted)}
 .record-type.text{background:rgba(59,130,246,0.15);color:#93c5fd}
 .record-type.code{background:rgba(168,85,247,0.15);color:#c4b5fd}
 .record-type.file{background:rgba(34,197,94,0.15);color:#86efac}
@@ -72,14 +72,14 @@ input{font-family:inherit;outline:none}
 .detail-panel{position:fixed;top:0;right:-500px;width:500px;height:100vh;background:var(--surface2);border-left:1px solid var(--border);z-index:60;display:flex;flex-direction:column;transition:right 0.3s ease}
 .detail-panel.open{right:0}
 .detail-header{padding:1rem 1.5rem;display:flex;align-items:center;gap:0.8rem;border-bottom:1px solid var(--border);flex-shrink:0}
-.detail-type{font-size:0.8rem;padding:0.3rem 0.6rem;border-radius:4px;background:rgba(255,255,255,0.06);color:var(--muted)}
+.detail-type{font-size:0.8rem;padding:0.3rem 0.6rem;border-radius:4px;background:var(--badge-bg);color:var(--muted)}
 .detail-time{font-size:0.8rem;color:var(--muted)}
 .detail-actions{display:flex;gap:0.4rem;margin-left:auto}
-.detail-btn{padding:0.4rem 0.8rem;border-radius:6px;font-size:0.8rem;background:rgba(255,255,255,0.06);color:var(--muted);transition:all 0.2s}
-.detail-btn:hover{background:rgba(255,255,255,0.1);color:var(--text)}
+.detail-btn{padding:0.4rem 0.8rem;border-radius:6px;font-size:0.8rem;background:var(--badge-bg);color:var(--muted);transition:all 0.2s}
+.detail-btn:hover{background:var(--hover-bg2);color:var(--text)}
 .detail-btn.danger:hover{background:rgba(239,68,68,0.15);color:var(--red)}
 .detail-close{width:32px;height:32px;border-radius:6px;background:transparent;color:var(--muted);font-size:1.2rem;display:flex;align-items:center;justify-content:center;transition:all 0.2s;flex-shrink:0}
-.detail-close:hover{background:rgba(255,255,255,0.1);color:var(--text)}
+.detail-close:hover{background:var(--hover-bg2);color:var(--text)}
 .detail-content{flex:1;padding:1.5rem;overflow-y:auto}
 .detail-content pre{font-family:'Cascadia Code','Consolas',monospace;font-size:0.85rem;line-height:1.6;white-space:pre-wrap;word-break:break-all;color:var(--text)}
 .detail-content pre img{max-width:100%;border-radius:8px;margin-top:0.5rem}
@@ -108,7 +108,7 @@ input{font-family:inherit;outline:none}
 .detail-preview li{margin:0.3rem 0}
 .detail-preview table{width:100%;border-collapse:collapse;margin:0.8rem 0}
 .detail-preview th,.detail-preview td{border:1px solid var(--border);padding:0.5rem 0.8rem;text-align:left}
-.detail-preview th{background:rgba(255,255,255,0.05);font-weight:600}
+.detail-preview th{background:var(--hover-bg);font-weight:600}
 .detail-preview hr{border:none;height:1px;background:var(--border);margin:1.2rem 0}
 .detail-preview .task-list-item{list-style:none;margin-left:-1.5rem}
 [data-theme="light"] .detail-preview code{background:rgba(99,102,241,0.08)}
@@ -154,7 +154,7 @@ input{font-family:inherit;outline:none}
 .icon-btn#btnViewToggle.active{background:var(--accent-bg);color:var(--accent)}
 .select-all-btn{display:none;margin-left:auto}
 .select-all-btn.show{display:block}
-.batch-bar{position:fixed;bottom:0;left:0;right:0;height:60px;padding:0 1.5rem;display:flex;align-items:center;gap:1rem;background:rgba(8,11,18,0.95);backdrop-filter:blur(20px);border-top:1px solid var(--border);z-index:50;transform:translateY(100%);transition:transform 0.3s ease}
+.batch-bar{position:fixed;bottom:0;left:0;right:0;height:60px;padding:0 1.5rem;display:flex;align-items:center;gap:1rem;background:var(--header-bg,rgba(8,11,18,0.95));backdrop-filter:blur(20px);border-top:1px solid var(--border);z-index:50;transform:translateY(100%);transition:transform 0.3s ease}
 .batch-bar.show{transform:translateY(0)}
 .batch-count{color:var(--muted);font-size:0.9rem}
 .batch-count strong{color:var(--accent)}
@@ -175,7 +175,7 @@ input{font-family:inherit;outline:none}
 .timeline-view{padding:0}
 .timeline-group{margin-bottom:0.5rem;border:1px solid var(--border);border-radius:12px;background:var(--surface);overflow:hidden}
 .timeline-group-header{display:flex;align-items:center;padding:1rem 1.2rem;cursor:pointer;transition:all 0.2s;gap:0.8rem}
-.timeline-group-header:hover{background:rgba(255,255,255,0.03)}
+.timeline-group-header:hover{background:var(--hover-bg)}
 .timeline-group-title{font-weight:600;color:var(--text);flex:1}
 .timeline-group-count{font-size:0.8rem;color:var(--muted)}
 .timeline-group-toggle{font-size:0.75rem;color:var(--muted);transition:transform 0.2s}

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -1,4 +1,4 @@
-
+﻿
 /* v0.24.0: 分组管理样式 */
 .groups-sidebar{position:fixed;left:0;top:108px;bottom:0;width:200px;background:var(--surface);border-right:1px solid var(--border);z-index:30;display:flex;flex-direction:column;transform:translateX(-100%);transition:transform 0.3s ease}
 .groups-sidebar.show{transform:translateX(0)}
@@ -7,14 +7,14 @@
 .icon-btn-sm:hover{background:var(--accent-bg);color:var(--accent)}
 .groups-list{flex:1;overflow-y:auto;padding:0.5rem}
 .group-item{display:flex;align-items:center;padding:0.6rem 0.8rem;border-radius:8px;cursor:pointer;transition:all 0.2s;gap:0.5rem}
-.group-item:hover{background:rgba(255,255,255,0.05)}
+.group-item:hover{background:var(--hover-bg)}
 .group-item.active{background:var(--accent-bg)}
 .group-item.active .group-name{color:var(--accent);font-weight:600}
 .group-icon{font-size:1rem}
 .group-name{font-size:0.85rem;color:var(--text);flex:1}
 .group-edit{font-size:0.75rem;padding:0.2rem 0.4rem;background:transparent;color:var(--muted);border-radius:4px;opacity:0;transition:opacity 0.2s}
 .group-item:hover .group-edit{opacity:1}
-.group-edit:hover{color:var(--accent);background:rgba(255,255,255,0.1)}
+.group-edit:hover{color:var(--accent);background:var(--hover-bg2)}
 .group-item.drag-over{background:var(--accent-bg);outline:2px dashed var(--accent)}
 .groups-sidebar.show~.main{left:200px}
 


### PR DESCRIPTION
## 变更内容

- 添加「跟随系统」主题选项（自动检测 OS 主题偏好）
- 监听系统主题变化实时切换
- CSS 变量化所有硬编码颜色（header/tabs/hover/badge 等）
- 新增 \--header-bg\ \--tabs-bg\ \--hover-bg\ \--hover-bg2\ \--badge-bg\ \--scrollbar-hover\ \--btn-bg\ \--table-header-bg\ 等主题变量
- 亮色主题完整适配（修复 header/tabs/batch-bar 背景）
- 主题切换过渡动画

Closes #81