### PR TITLE
feat: 关于面板诊断信息 v0.37.0

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1692,3 +1692,38 @@ ipcMain.handle('read-file', async (_, { filePath }) => {
     return { success: false, error: err.message };
   }
 });
+
+// ==================== v0.37.0: 诊断信息 ====================
+
+ipcMain.handle('get-diagnostics', async () => {
+  try {
+    const memUsage = process.memoryUsage();
+    const dbPath = path.join(app.getPath('userData'), 'clawboard.db');
+    let dbSize = 0;
+    if (fs.existsSync(dbPath)) {
+      dbSize = fs.statSync(dbPath).size;
+    }
+    const stats = db.getStats();
+    return {
+      appVersion: app.getVersion(),
+      electronVersion: process.versions.electron,
+      nodeVersion: process.versions.node,
+      chromeVersion: process.versions.chrome,
+      platform: process.platform,
+      arch: process.arch,
+      osRelease: require('os').release(),
+      totalMemory: Math.round(require('os').totalmem() / 1024 / 1024),
+      heapUsed: Math.round(memUsage.heapUsed / 1024 / 1024),
+      heapTotal: Math.round(memUsage.heapTotal / 1024 / 1024),
+      dbSize: dbSize,
+      recordCount: stats.total,
+      favoriteCount: stats.favorite,
+      userDataPath: app.getPath('userData'),
+      dbPath: dbPath,
+      uptime: Math.round(process.uptime()),
+    };
+  } catch (err) {
+    log.error('get-diagnostics error:', err);
+    return { error: err.message };
+  }
+});

--- a/src/preload.js
+++ b/src/preload.js
@@ -136,6 +136,8 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   writeFile: (data) => ipcRenderer.invoke('write-file', data),
   readFile: (data) => ipcRenderer.invoke('read-file', data),
   onHotkeyTriggered: (callback) => ipcRenderer.on('hotkey-triggered', (_, data) => callback(data)),
+  // v0.37.0: 诊断信息
+  getDiagnostics: () => ipcRenderer.invoke('get-diagnostics'),
 
   // 移除监听
   removeAllListeners: (channel) => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -55,6 +55,7 @@
   async function init() {
     setupEventListeners();
     initShortcutRecording();  // 初始化快捷键录制
+    initAboutPanel();         // v0.37.0: 初始化关于面板
     loadSearchHistory();      // v0.35.0: 加载搜索历史
     initSearchHistoryUI();    // v0.35.0: 初始化搜索历史下拉
     await loadGroups();
@@ -187,6 +188,8 @@
         $('#' + tabId).classList.add('show');
         // v0.32.0: 切换到快捷模板 tab 时加载槽位
         if (tab.dataset.tab === 'hotkeys') loadHotkeySlots();
+        // v0.37.0: 切换到关于 tab 时加载诊断信息
+        if (tab.dataset.tab === 'about') loadDiagnostics();
       });
     });
 
@@ -3122,6 +3125,53 @@
     setTimeout(() => {
       toast.classList.remove('show');
     }, 2500);
+  }
+
+  // ==================== v0.37.0: 关于 & 诊断信息 ====================
+  let _diagnosticsText = '';
+
+  async function loadDiagnostics() {
+    try {
+      const d = await window.ClawBoard.getDiagnostics();
+      if (d.error) {
+        $('#diagnosticsInfo').innerHTML = '<span style="color:var(--red)">加载失败: ' + d.error + '</span>';
+        return;
+      }
+      const formatSize = (bytes) => bytes < 1024 ? bytes + ' B' : bytes < 1048576 ? (bytes/1024).toFixed(1) + ' KB' : (bytes/1048576).toFixed(1) + ' MB';
+      const uptimeH = Math.floor(d.uptime / 3600);
+      const uptimeM = Math.floor((d.uptime % 3600) / 60);
+      const lines = [
+        ['📋 版本', 'ClawBoard v' + d.appVersion],
+        ['⚡ Electron', d.electronVersion],
+        ['🟢 Node.js', d.nodeVersion],
+        ['🌐 Chromium', d.chromeVersion],
+        ['💻 系统', d.platform + ' ' + d.osRelease + ' (' + d.arch + ')'],
+        ['🧠 内存', d.heapUsed + ' MB / ' + d.heapTotal + ' MB (系统 ' + d.totalMemory + ' MB)'],
+        ['📦 数据库', formatSize(d.dbSize) + ' · ' + d.recordCount + ' 条记录 · ' + d.favoriteCount + ' 个收藏'],
+        ['⏱ 运行时间', uptimeH + '时' + uptimeM + '分'],
+        ['📂 数据路径', d.userDataPath],
+      ];
+      _diagnosticsText = lines.map(l => l[0].replace(/[^\w\s.]/g,'').trim() + ': ' + l[1]).join('\n');
+      $('#diagnosticsInfo').innerHTML = lines.map(([icon_label, value]) =>
+        '<div><strong>' + icon_label + '</strong> ' + value + '</div>'
+      ).join('');
+      $('#aboutVersion').textContent = 'v' + d.appVersion;
+    } catch (e) {
+      $('#diagnosticsInfo').innerHTML = '<span style="color:var(--red)">加载失败</span>';
+    }
+  }
+
+  function initAboutPanel() {
+    const btn = $('#btnCopyDiagnostics');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        if (_diagnosticsText) {
+          navigator.clipboard.writeText(_diagnosticsText).then(() => {
+            showToast('📋 诊断信息已复制', 'success');
+          });
+        }
+      });
+    }
   }
 
   // ==================== 启动 ====================

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -403,6 +403,7 @@
         <button class="settings-tab" data-tab="expiry">🗑️ 数据管理</button>
         <button class="settings-tab" data-tab="importExport">📥 导入导出</button>
         <button class="settings-tab" data-tab="hotkeys">⚡ 快捷模板</button>
+        <button class="settings-tab" data-tab="about">ℹ️ 关于</button>
       </div>
       <div class="settings-body">
         <!-- 通用设置 -->
@@ -589,6 +590,23 @@
           </div>
           <div style="margin-top:1rem;padding:0.8rem;background:var(--surface2);border-radius:8px;font-size:0.82rem;color:var(--muted)">
             💡 支持模板变量：<code>{{date}}</code> 日期、<code>{{time}}</code> 时间、<code>{{datetime}}</code> 日期时间、<code>{{clipboard}}</code> 当前剪贴板
+          </div>
+        </div>
+        <!-- v0.37.0: 关于 & 诊断 -->
+        <div class="settings-tab-content" id="settingsAbout" style="display:none">
+          <div class="about-header" style="text-align:center;padding:1.5rem 0">
+            <div style="font-size:2.5rem">📋</div>
+            <h3 style="margin:0.5rem 0 0.2rem;font-size:1.3rem">ClawBoard</h3>
+            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.36.0</div>
+          </div>
+          <div class="diagnostics-box" style="background:var(--surface2);border-radius:10px;padding:1rem;font-size:0.82rem;line-height:1.8">
+            <div id="diagnosticsInfo">加载中…</div>
+          </div>
+          <div class="setting-item" style="margin-top:1rem">
+            <button class="btn-secondary" id="btnCopyDiagnostics">📋 复制诊断信息</button>
+          </div>
+          <div class="setting-item" style="margin-top:0.5rem">
+            <a href="https://github.com/NotSleeply/ClawBoard" target="_blank" style="color:var(--accent);text-decoration:none;font-size:0.9rem">🔗 GitHub 仓库</a>
           </div>
         </div>
       </div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -191,7 +191,7 @@ input{font-family:inherit;outline:none}
 .settings-tab:hover{color:var(--text)}
 .settings-tab.active{color:var(--accent);border-bottom-color:var(--accent)}
 .settings-tab-content{display:none}
-.settings-tab-content.show{display:block}
+.settings-tab-content.show{display:block!important}
 .shortcuts-list{display:flex;flex-direction:column;gap:0.8rem}
 .shortcut-item{display:flex;align-items:center;justify-content:space-between;padding:0.6rem 0.8rem;background:var(--surface);border:1px solid var(--border);border-radius:8px}
 .shortcut-label{font-size:0.9rem;color:var(--text)}


### PR DESCRIPTION
## 变更内容

- 新增「关于」设置标签页（ℹ️ 关于）
- 显示应用版本、Electron/Node/Chromium 版本
- 显示系统信息（平台、架构、OS 版本、总内存）
- 显示运行时状态（堆内存、数据库大小、记录数、收藏数、运行时间）
- 一键复制诊断信息到剪贴板
- GitHub 仓库链接
- 修复 settings-tab-content 切换显示优先级问题

Closes #83