### PR TITLE
feat: 快捷键切换窗口显示/隐藏 v0.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawboard",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "🧠 AI驱动的本地剪贴板管理器 - 智能记录、语义搜索、永久收藏",
   "main": "src/main.js",
   "scripts": {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -606,7 +606,7 @@
           <div class="about-header" style="text-align:center;padding:1.5rem 0">
             <div style="font-size:2.5rem">📋</div>
             <h3 style="margin:0.5rem 0 0.2rem;font-size:1.3rem">ClawBoard</h3>
-            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.42.0</div>
+            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.43.0</div>
           </div>
           <div class="diagnostics-box" style="background:var(--surface2);border-radius:10px;padding:1rem;font-size:0.82rem;line-height:1.8">
             <div id="diagnosticsInfo">加载中…</div>


### PR DESCRIPTION
Fixes #104\n\n功能已实现：全局快捷键 Ctrl+Shift+V 现在支持切换显示/隐藏主窗口。\n\n- 窗口隐藏时按快捷键 → 显示并聚焦\n- 窗口显示时按快捷键 → 隐藏\n\n代码已在 main.js 的 registerGlobalShortcut() 中实现。