### PR TITLE
feat: 超长文本/大代码块渲染与编辑性能优化 v0.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawboard",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "🧠 AI驱动的本地剪贴板管理器 - 智能记录、语义搜索、永久收藏",
   "main": "src/main.js",
   "scripts": {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -236,7 +236,17 @@
         textarea.wrap = 'off';
       }
     });
-    $('#editorTextarea').addEventListener('input', updateEditorStats);
+    // v0.44.0: 性能模式切换
+    $('#editorPerfToggle').addEventListener('change', (e) => {
+      togglePerfMode(e.target.checked);
+      if (!e.target.checked) updateEditorStats();
+      else {
+        const textarea = $('#editorTextarea');
+        const chars = textarea.value.length;
+        $('#editorStats').textContent = `${chars} 字符 · 性能模式`;
+      }
+    });
+    $('#editorTextarea').addEventListener('input', debouncedUpdateEditorStats);
     // Ctrl+S 保存
     $('#editorTextarea').addEventListener('keydown', (e) => {
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
@@ -1912,6 +1922,11 @@
     return card;
   }
 
+  // v0.44.0: 长文本性能阈值
+  const LONG_TEXT_LINE_THRESHOLD = 10; // 列表预览最大行数
+  const LONG_TEXT_CHAR_THRESHOLD = 5000; // 性能模式字符阈值
+  const HIGHLIGHT_MATCH_LIMIT = 100; // 搜索高亮最大匹配数
+
   function formatContent(record) {
     if (record.type === 'image') {
       let imgHtml = `<img src="file://${record.content}" alt="图片" loading="lazy">`;
@@ -1924,7 +1939,12 @@
     }
 
     let text = escapeHtml(record.content || record.summary || '');
-    if (text.length > 200) {
+    const lines = text.split('\n');
+
+    // v0.44.0: 按行截断预览，替代仅按字符数截断
+    if (lines.length > LONG_TEXT_LINE_THRESHOLD) {
+      text = lines.slice(0, LONG_TEXT_LINE_THRESHOLD).join('\n') + `\n<span class="long-text-hint">... 还有 ${lines.length - LONG_TEXT_LINE_THRESHOLD} 行</span>`;
+    } else if (text.length > 200) {
       text = text.substring(0, 197) + '...';
     }
     // v0.35.0: 搜索高亮
@@ -1935,14 +1955,18 @@
   }
 
   // v0.35.0: 搜索关键词高亮
+  // v0.44.0: 限制高亮匹配数量，避免大文本重渲染卡顿
   function highlightText(text, query) {
     if (!query || query.length < 1) return text;
     try {
-      // 转义正则特殊字符
       const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      // 大小写不敏感匹配，高亮所有匹配项
       const regex = new RegExp(`(${escaped})`, 'gi');
-      return text.replace(regex, '<mark class="search-highlight">$1</mark>');
+      let count = 0;
+      return text.replace(regex, (match) => {
+        if (count >= HIGHLIGHT_MATCH_LIMIT) return match;
+        count++;
+        return `<mark class="search-highlight">${match}</mark>`;
+      });
     } catch (e) {
       return text;
     }
@@ -2157,7 +2181,21 @@
       $('#editorWrapToggle').checked = false;
     }
 
-    updateEditorStats();
+    // v0.44.0: 性能模式 — 超长文本自动启用
+    const content = selectedRecord.content || '';
+    const isLongText = content.length > LONG_TEXT_CHAR_THRESHOLD;
+    const perfToggle = $('#editorPerfToggle');
+    if (perfToggle) {
+      perfToggle.checked = isLongText;
+      togglePerfMode(isLongText);
+    }
+
+    if (!isLongText) {
+      updateEditorStats();
+    } else {
+      $('#editorStats').textContent = `${content.length} 字符 · 性能模式`;
+    }
+
     $('#editorOverlay').classList.add('show');
     textarea.focus();
   }
@@ -2165,6 +2203,29 @@
   function closeEditor() {
     $('#editorOverlay').classList.remove('show');
     editorRecordId = null;
+  }
+
+  // v0.44.0: 性能模式切换
+  function togglePerfMode(enabled) {
+    const textarea = $('#editorTextarea');
+    if (enabled) {
+      textarea.classList.add('perf-mode');
+      // 性能模式：禁用拼写检查和实时统计
+      textarea.spellcheck = false;
+    } else {
+      textarea.classList.remove('perf-mode');
+      textarea.spellcheck = false; // 原本就是 false
+      updateEditorStats();
+    }
+  }
+
+  // v0.44.0: 防抖的编辑器统计更新
+  let editorStatsTimer = null;
+  function debouncedUpdateEditorStats() {
+    const perfToggle = document.getElementById('editorPerfToggle');
+    if (perfToggle && perfToggle.checked) return; // 性能模式跳过实时统计
+    clearTimeout(editorStatsTimer);
+    editorStatsTimer = setTimeout(updateEditorStats, 500);
   }
 
   function updateEditorStats() {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -606,7 +606,7 @@
           <div class="about-header" style="text-align:center;padding:1.5rem 0">
             <div style="font-size:2.5rem">📋</div>
             <h3 style="margin:0.5rem 0 0.2rem;font-size:1.3rem">ClawBoard</h3>
-            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.43.0</div>
+            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.44.0</div>
           </div>
           <div class="diagnostics-box" style="background:var(--surface2);border-radius:10px;padding:1rem;font-size:0.82rem;line-height:1.8">
             <div id="diagnosticsInfo">加载中…</div>
@@ -728,6 +728,9 @@
         <div style="display:flex;gap:0.5rem;align-items:center">
           <label style="font-size:0.82rem;color:var(--muted);display:flex;align-items:center;gap:0.3rem">
             <input type="checkbox" id="editorWrapToggle" checked> 自动换行
+          </label>
+          <label style="font-size:0.82rem;color:var(--muted);display:flex;align-items:center;gap:0.3rem" title="长文本时自动启用，禁用实时统计以提升性能">
+            <input type="checkbox" id="editorPerfToggle"> ⚡ 性能模式
           </label>
         </div>
         <div style="display:flex;gap:0.5rem">

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -3,6 +3,9 @@
 .editor-textarea{width:100%;padding:1rem;background:var(--surface);color:var(--text);border:1px solid var(--border);border-radius:8px;font-family:'Cascadia Code','Fira Code','Consolas',monospace;font-size:0.9rem;line-height:1.6;resize:vertical;tab-size:4;outline:none;transition:border-color 0.2s}
 .editor-textarea:focus{border-color:var(--accent)}
 .editor-textarea.no-wrap{white-space:pre;overflow-x:auto}
+.editor-textarea.perf-mode{font-size:0.85rem;line-height:1.4;letter-spacing:0}
+/* v0.44.0: 长文本截断提示 */
+.long-text-hint{display:block;color:var(--muted);font-size:0.8rem;font-style:italic;margin-top:0.25rem;padding:0.15rem 0.4rem;background:var(--surface-alt);border-radius:3px}
 .editor-code-preview{font-family:'Cascadia Code','Fira Code','Consolas',monospace;font-size:0.85rem;line-height:1.6;border:1px solid var(--border)}
 .editor-code-preview pre{margin:0;padding:0}
 .editor-code-preview code{font-size:0.85rem}


### PR DESCRIPTION
Fixes #96

## 改动

- **列表预览按行截断**: 超过10行的内容折叠，显示剩余行数提示，替代原仅按字符截断
- **编辑器性能模式**: 超过5000字符自动启用⚡性能模式（禁用实时统计更新），可手动开关
- **搜索高亮限流**: 最多高亮100个匹配项，避免大文本全量重渲染卡顿
- **防抖统计更新**: 编辑器字符/行数统计改为500ms防抖

## 文件变更
- src/renderer/app.js: formatContent行截断、highlightText限流、性能模式逻辑、防抖统计
- src/renderer/index.html: 性能模式开关UI、版本号
- src/renderer/styles_extra.css: 性能模式样式、长文本提示样式