### PR TITLE
feat: 数据管理面板添加存储大小显示 v0.44.0

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -70,6 +70,8 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   
   // v0.26.0: 运行时健康监控
   getRuntimeStats: () => ipcRenderer.invoke('get-runtime-stats'),
+  // v0.44.0: 系统健康状态（包含数据库大小）
+  getSystemHealth: () => ipcRenderer.invoke('get-system-health'),
 
   // v0.27.0: 置顶记录管理
   getPinnedRecords: (options) => ipcRenderer.invoke('get-pinned-records', options),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -2976,11 +2976,27 @@
   }
 
   // v0.31.0: 加载过期统计
+  // v0.44.0: 添加存储大小显示
   async function loadExpiryStats() {
     try {
       const stats = await window.ClawBoard.getExpiryStats();
       $('#expiryExpiredCount').textContent = stats.expired;
       $('#expiryProtectedCount').textContent = stats.protected;
+      
+      // v0.44.0: 加载存储大小和记录数
+      const health = await window.ClawBoard.getSystemHealth();
+      if (health) {
+        const formatStorageSize = (bytes) => {
+          if (bytes < 1024) return bytes + ' B';
+          if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+          if (bytes < 1024 * 1024 * 1024) return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+          return (bytes / 1024 / 1024 / 1024).toFixed(2) + ' GB';
+        };
+        $('#storageSize').textContent = formatStorageSize(health.dbSize);
+        // 获取总记录数
+        const dbStats = await window.ClawBoard.getStats();
+        $('#recordCount').textContent = dbStats.total || 0;
+      }
     } catch (e) {
       console.error('加载过期统计失败:', e);
     }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -555,6 +555,12 @@
           <div class="expiry-stats" id="expiryStats" style="margin-top:1rem;padding:0.8rem;background:var(--surface2);border-radius:8px;font-size:0.85rem">
             <div>📝 当前有过期条目：<strong id="expiryExpiredCount">-</strong> 条可清理</div>
             <div style="margin-top:0.3rem;color:var(--muted)">⭐ 收藏保护：<strong id="expiryProtectedCount">-</strong> 条</div>
+            <div style="margin-top:0.5rem;padding-top:0.5rem;border-top:1px solid var(--border)">
+              <span style="display:flex;justify-content:space-between;align-items:center">
+                <span>💾 数据库存储</span>
+                <span><strong id="storageSize">-</strong> (<strong id="recordCount">-</strong> 条记录)</span>
+              </span>
+            </div>
           </div>
           <div class="setting-item" style="margin-top:1rem">
             <button class="btn-secondary" id="btnCleanExpired">🗑️ 立即清理过期条目</button>


### PR DESCRIPTION
## 功能描述

在设置面板的「数据管理」标签中添加数据库存储大小和记录数显示，借鉴 Maccy 的 Storage 信息展示功能。

## 变更内容

- 修改 \src/renderer/index.html\：在 expiry-stats 区域添加存储大小和记录数显示
- 修改 \src/renderer/app.js\：在 loadExpiryStats 函数中添加获取存储大小的逻辑
- 修改 \src/preload.js\：暴露 getSystemHealth API

## 截图

数据管理面板新增：
- 💾 数据库存储：显示数据库文件大小（自动格式化 B/KB/MB/GB）
- 记录数：显示当前总记录数

## 测试

- [x] 打开设置 → 数据管理标签
- [x] 确认存储大小和记录数正确显示
- [x] 清理记录后数值更新正确

## 关联

借鉴 Maccy 2026.07 更新中的「Added information about the database size on disk in Settings / Storage」功能。