### PR TITLE
feat: 敏感内容自动加密规则自定义 v0.45.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawboard",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "🧠 AI驱动的本地剪贴板管理器 - 智能记录、语义搜索、永久收藏",
   "main": "src/main.js",
   "scripts": {

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -72,6 +72,30 @@ class ClipboardWatcher {
     const trimmed = text.trim();
     if (!trimmed) return;
 
+    // v0.45.0: 检查忽略规则（含自动加密逻辑）
+    if (global.ignoreRules) {
+      const ignoreResult = global.ignoreRules.shouldIgnore(trimmed, {
+        sourceApp: this.currentSource.app
+      });
+      
+      // 自动加密：检测到敏感信息但需要加密而非忽略
+      if (ignoreResult.autoEncrypt) {
+        // 需要加密密钥才能自动加密
+        if (global.db && global.db.encryptionKey) {
+          this.log.info(`自动加密: ${ignoreResult.reason}`);
+          // 继续处理，但标记为加密
+          this._handleTextWithEncrypt(trimmed, ignoreResult.types);
+          return;
+        } else {
+          // 没有加密密钥，仍记录但不加密，添加敏感类型标记
+          this.log.warn('自动加密: 未设置加密密码，仅标记敏感类型');
+        }
+      } else if (ignoreResult.shouldIgnore) {
+        this.log.info(`忽略剪贴板内容: ${ignoreResult.reason}`);
+        return;
+      }
+    }
+
     // 判断类型
     let type = 'text';
     let content = trimmed;
@@ -138,6 +162,80 @@ class ClipboardWatcher {
       // v0.29.0: 触发系统通知
       if (global.showClipboardNotification) {
         global.showClipboardNotification(record);
+      }
+    });
+  }
+
+  /**
+   * v0.45.0: 处理需要自动加密的文本
+   */
+  _handleTextWithEncrypt(text, sensitiveTypes) {
+    let type = 'text';
+    if (this._isFilePath(text)) {
+      type = 'file';
+    } else if (this._isCode(text)) {
+      type = 'code';
+    }
+
+    const language = type === 'code' ? this._detectLanguage(text) : null;
+    const sensitiveTypesStr = sensitiveTypes.join(',');
+
+    // 检查去重
+    const lastRecords = this.db.getRecords({ limit: 1 });
+    if (lastRecords.length > 0 && lastRecords[0].content === text && !lastRecords[0].locked) {
+      this.log.info('内容重复，跳过记录');
+      return;
+    }
+
+    this._generateAI(text).then(aiResult => {
+      const record = this.db.addRecord({
+        type,
+        content: text,
+        summary: (aiResult && aiResult.summary) || this._generateSummary(text),
+        ai_summary: aiResult && aiResult.summary,
+        embedding: aiResult && aiResult.embedding,
+        language,
+        source: 'clipboard',
+        encrypted: true, // 自动加密
+        sensitive_types: sensitiveTypesStr,
+      });
+
+      this.log.info(`自动加密记录: [${type}] ${sensitiveTypesStr} → 已加密`);
+
+      if (global.mainWindow && !global.mainWindow.isDestroyed()) {
+        global.mainWindow.webContents.send('new-record', record);
+      }
+
+      if (global.showClipboardNotification) {
+        global.showClipboardNotification({
+          ...record,
+          _autoEncrypted: true,
+          _sensitiveTypes: sensitiveTypes,
+        });
+      }
+    }).catch(err => {
+      this.log.warn('AI 处理失败，使用默认摘要:', err.message);
+      const record = this.db.addRecord({
+        type,
+        content: text,
+        summary: this._generateSummary(text),
+        source: 'clipboard',
+        encrypted: true,
+        sensitive_types: sensitiveTypesStr,
+      });
+
+      this.log.info(`自动加密记录: [${type}] ${sensitiveTypesStr} → 已加密`);
+
+      if (global.mainWindow && !global.mainWindow.isDestroyed()) {
+        global.mainWindow.webContents.send('new-record', record);
+      }
+
+      if (global.showClipboardNotification) {
+        global.showClipboardNotification({
+          ...record,
+          _autoEncrypted: true,
+          _sensitiveTypes: sensitiveTypes,
+        });
       }
     });
   }

--- a/src/database.js
+++ b/src/database.js
@@ -135,6 +135,13 @@ class Database {
       // 列已存在，忽略
     }
 
+    // 添加敏感类型列（如果不存在）- v0.45.0 自动加密规则
+    try {
+      this.db.run(`ALTER TABLE records ADD COLUMN sensitive_types TEXT DEFAULT ''`);
+    } catch (e) {
+      // 列已存在，忽略
+    }
+
     // 创建分组表
     this.db.run(`
       CREATE TABLE IF NOT EXISTS groups (
@@ -181,15 +188,15 @@ class Database {
   }
 
   // 添加记录
-  addRecord({ type, content, summary, source, source_app, source_title, source_url, tags = '[]', ai_summary = null, embedding = null, language = null, encrypted = false, ocr_text = null, merged_from = null, is_merged = false }) {
+  addRecord({ type, content, summary, source, source_app, source_title, source_url, tags = '[]', ai_summary = null, embedding = null, language = null, encrypted = false, ocr_text = null, merged_from = null, is_merged = false, sensitive_types = '' }) {
     let finalContent = content;
     if (encrypted && this.encryptionKey) {
       finalContent = this._encrypt(content, this.encryptionKey);
     }
 
     this.db.run(
-      `INSERT INTO records (type, content, summary, source, source_app, source_title, source_url, tags, ai_summary, embedding, language, encrypted, ocr_text, merged_from, is_merged) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [type, finalContent, summary, source || 'clipboard', source_app || null, source_title || null, source_url || null, tags, ai_summary, embedding, language, encrypted ? 1 : 0, ocr_text, merged_from, is_merged ? 1 : 0]
+      `INSERT INTO records (type, content, summary, source, source_app, source_title, source_url, tags, ai_summary, embedding, language, encrypted, ocr_text, merged_from, is_merged, sensitive_types) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [type, finalContent, summary, source || 'clipboard', source_app || null, source_title || null, source_url || null, tags, ai_summary, embedding, language, encrypted ? 1 : 0, ocr_text, merged_from, is_merged ? 1 : 0, sensitive_types]
     );
 
     // 自动清理旧记录（保留收藏）

--- a/src/ignore-rules.js
+++ b/src/ignore-rules.js
@@ -1,6 +1,7 @@
 /**
  * IgnoreRules - 剪贴板忽略规则模块 v0.31.0
  * 支持按来源应用、内容模式、长度等条件忽略剪贴板内容
+ * v0.45.0: 新增敏感内容自动加密规则
  */
 
 class IgnoreRules {
@@ -36,6 +37,18 @@ class IgnoreRules {
           { name: 'API 密钥', pattern: '(?:api[_-]?key|apikey|token)\s*[:=]\s*["\']?[a-zA-Z0-9_-]{16,}["\']?' },
         ],
       },
+      // v0.45.0: 自动加密规则
+      autoEncrypt: {
+        enabled: false, // 总开关，默认关闭
+        rules: [
+          { name: '信用卡号', enabled: true, type: 'credit_card' },
+          { name: '身份证号', enabled: true, type: 'id_card' },
+          { name: 'API 密钥', enabled: true, type: 'api_key' },
+          { name: '手机号', enabled: false, type: 'phone' },
+        ],
+        // 自定义规则（用户可添加正则表达式）
+        customRules: [],
+      },
     };
 
     // 忽略的剪贴板内容缓存（用于去重）
@@ -47,7 +60,7 @@ class IgnoreRules {
    * 检查是否应该忽略此剪贴板内容
    * @param {string} content - 剪贴板内容
    * @param {object} metadata - 元数据（来源应用等）
-   * @returns {object} { shouldIgnore: boolean, reason: string }
+   * @returns {object} { shouldIgnore: boolean, reason: string, sensitive: boolean, types: string[], autoEncrypt: boolean }
    */
   shouldIgnore(content, metadata = {}) {
     // 1. 检查长度限制
@@ -86,8 +99,22 @@ class IgnoreRules {
     if (this.rules.sensitiveDetection.enabled) {
       const sensitiveInfo = this.detectSensitiveInfo(content);
       if (sensitiveInfo.found) {
-        return { 
-          shouldIgnore: true, 
+        // v0.45.0: 检查是否需要自动加密而非忽略
+        if (this.rules.autoEncrypt.enabled) {
+          const autoEncryptTypes = this._getAutoEncryptTypes(content);
+          if (autoEncryptTypes.length > 0) {
+            return {
+              shouldIgnore: false,
+              reason: `检测到敏感信息，将自动加密: ${autoEncryptTypes.join(', ')}`,
+              sensitive: true,
+              types: autoEncryptTypes,
+              autoEncrypt: true,
+            };
+          }
+        }
+        // 自动加密未开启时，保持原有忽略行为
+        return {
+          shouldIgnore: true,
           reason: `检测到敏感信息: ${sensitiveInfo.types.join(', ')}`,
           sensitive: true,
           types: sensitiveInfo.types,
@@ -109,6 +136,59 @@ class IgnoreRules {
     }
 
     return { shouldIgnore: false, reason: '' };
+  }
+
+  /**
+   * v0.45.0: 获取需要自动加密的敏感类型列表
+   * @param {string} content - 内容
+   * @returns {string[]} 匹配到的敏感类型名称
+   */
+  _getAutoEncryptTypes(content) {
+    const matchedTypes = [];
+
+    // 检查内置规则
+    for (const rule of this.rules.autoEncrypt.rules) {
+      if (!rule.enabled) continue;
+      const pattern = this.rules.sensitiveDetection.patterns.find(p => p.name === rule.name);
+      if (pattern) {
+        try {
+          const regex = new RegExp(pattern.pattern, 'i');
+          if (regex.test(content)) {
+            matchedTypes.push(rule.name);
+          }
+        } catch (e) {
+          console.error('[IgnoreRules] 自动加密正则错误:', rule.name);
+        }
+      }
+    }
+
+    // 检查手机号（v0.45.0 新增模式）
+    const phoneRule = this.rules.autoEncrypt.rules.find(r => r.type === 'phone');
+    if (phoneRule && phoneRule.enabled) {
+      try {
+        const phoneRegex = /\b1[3-9]\d{9}\b/;
+        if (phoneRegex.test(content)) {
+          matchedTypes.push('手机号');
+        }
+      } catch (e) {
+        console.error('[IgnoreRules] 手机号检测正则错误');
+      }
+    }
+
+    // 检查自定义规则
+    for (const customRule of this.rules.autoEncrypt.customRules) {
+      if (!customRule.enabled) continue;
+      try {
+        const regex = new RegExp(customRule.pattern, 'i');
+        if (regex.test(content)) {
+          matchedTypes.push(customRule.name);
+        }
+      } catch (e) {
+        console.error('[IgnoreRules] 自定义加密规则正则错误:', customRule.name);
+      }
+    }
+
+    return matchedTypes;
   }
 
   /**
@@ -188,6 +268,56 @@ class IgnoreRules {
    */
   setSensitiveDetection(enabled) {
     this.rules.sensitiveDetection.enabled = enabled;
+  }
+
+  // ==================== v0.45.0: 自动加密规则管理 ====================
+
+  /**
+   * 获取自动加密设置
+   */
+  getAutoEncryptSettings() {
+    return this.rules.autoEncrypt;
+  }
+
+  /**
+   * 设置自动加密总开关
+   */
+  setAutoEncryptEnabled(enabled) {
+    this.rules.autoEncrypt.enabled = enabled;
+  }
+
+  /**
+   * 切换单个内置规则的启用状态
+   */
+  toggleAutoEncryptRule(type, enabled) {
+    const rule = this.rules.autoEncrypt.rules.find(r => r.type === type);
+    if (rule) {
+      rule.enabled = enabled;
+    }
+  }
+
+  /**
+   * 添加自定义自动加密规则
+   */
+  addCustomAutoEncryptRule(name, pattern, enabled = true) {
+    this.rules.autoEncrypt.customRules.push({ name, pattern, enabled });
+  }
+
+  /**
+   * 移除自定义自动加密规则
+   */
+  removeCustomAutoEncryptRule(name) {
+    this.rules.autoEncrypt.customRules = this.rules.autoEncrypt.customRules.filter(r => r.name !== name);
+  }
+
+  /**
+   * 更新自定义自动加密规则
+   */
+  updateCustomAutoEncryptRule(name, updates) {
+    const rule = this.rules.autoEncrypt.customRules.find(r => r.name === name);
+    if (rule) {
+      Object.assign(rule, updates);
+    }
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -1150,6 +1150,9 @@ app.whenReady().then(async () => {
 
   // v0.29.0: 将通知函数暴露给全局，供剪贴板模块调用
   global.showClipboardNotification = showClipboardNotification;
+  // v0.45.0: 将数据库和忽略规则暴露给全局，供剪贴板模块自动加密使用
+  global.db = db;
+  global.ignoreRules = ignoreRules;
 
   // v0.31.0: 启动自动过期清理定时器
   startAutoExpiryTimer();
@@ -1614,6 +1617,118 @@ ipcMain.handle('test-ignore-rules', async (_, { content, metadata }) => {
   } catch (err) {
     log.error('test-ignore-rules error:', err);
     return { shouldIgnore: false, reason: '' };
+  }
+});
+
+// ==================== v0.45.0: 自动加密规则 ====================
+
+// 获取自动加密设置
+ipcMain.handle('get-auto-encrypt-settings', async () => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    return ignoreRules.getAutoEncryptSettings();
+  } catch (err) {
+    log.error('get-auto-encrypt-settings error:', err);
+    return null;
+  }
+});
+
+// 设置自动加密总开关
+ipcMain.handle('set-auto-encrypt-enabled', async (_, enabled) => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    ignoreRules.setAutoEncryptEnabled(enabled);
+    // 同步到设置面板的忽略规则
+    return { success: true };
+  } catch (err) {
+    log.error('set-auto-encrypt-enabled error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+// 切换自动加密内置规则
+ipcMain.handle('toggle-auto-encrypt-rule', async (_, { type, enabled }) => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    ignoreRules.toggleAutoEncryptRule(type, enabled);
+    return { success: true };
+  } catch (err) {
+    log.error('toggle-auto-encrypt-rule error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+// 添加自定义自动加密规则
+ipcMain.handle('add-custom-auto-encrypt-rule', async (_, { name, pattern }) => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    ignoreRules.addCustomAutoEncryptRule(name, pattern);
+    return { success: true };
+  } catch (err) {
+    log.error('add-custom-auto-encrypt-rule error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+// 移除自定义自动加密规则
+ipcMain.handle('remove-custom-auto-encrypt-rule', async (_, name) => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    ignoreRules.removeCustomAutoEncryptRule(name);
+    return { success: true };
+  } catch (err) {
+    log.error('remove-custom-auto-encrypt-rule error:', err);
+    return { success: false, error: err.message };
+  }
+});
+
+// 批量自动加密已有记录（扫描所有未加密记录）
+ipcMain.handle('batch-auto-encrypt', async () => {
+  try {
+    if (!ignoreRules) {
+      ignoreRules = new IgnoreRules();
+    }
+    if (!db.encryptionKey) {
+      return { success: false, message: '未设置加密密码' };
+    }
+    
+    const records = db.getRecords({ limit: 10000 });
+    let encryptedCount = 0;
+    let skippedCount = 0;
+    
+    for (const record of records) {
+      if (record.encrypted) { skippedCount++; continue; }
+      
+      const result = ignoreRules.shouldIgnore(record.content, {});
+      if (result.autoEncrypt) {
+        const success = db.encryptRecord(record.id);
+        if (success) {
+          // 更新敏感类型标记
+          db.db.run(
+            `UPDATE records SET sensitive_types = ? WHERE id = ?`,
+            [result.types ? result.types.join(',') : '', record.id]
+          );
+          encryptedCount++;
+        }
+      }
+    }
+    
+    db._save();
+    log.info(`批量自动加密完成: ${encryptedCount} 条已加密, ${skippedCount} 条跳过`);
+    return { success: true, encryptedCount, skippedCount };
+  } catch (err) {
+    log.error('batch-auto-encrypt error:', err);
+    return { success: false, message: err.message };
   }
 });\n
 // ==================== v0.31.0: 自动过期清理 ====================

--- a/src/preload.js
+++ b/src/preload.js
@@ -120,6 +120,14 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   removeIgnoredApp: (pattern) => ipcRenderer.invoke('remove-ignored-app', pattern),
   testIgnoreRules: (content, metadata) => ipcRenderer.invoke('test-ignore-rules', { content, metadata }),
 
+  // v0.45.0: 自动加密规则
+  getAutoEncryptSettings: () => ipcRenderer.invoke('get-auto-encrypt-settings'),
+  setAutoEncryptEnabled: (enabled) => ipcRenderer.invoke('set-auto-encrypt-enabled', enabled),
+  toggleAutoEncryptRule: (type, enabled) => ipcRenderer.invoke('toggle-auto-encrypt-rule', { type, enabled }),
+  addCustomAutoEncryptRule: (name, pattern) => ipcRenderer.invoke('add-custom-auto-encrypt-rule', { name, pattern }),
+  removeCustomAutoEncryptRule: (name) => ipcRenderer.invoke('remove-custom-auto-encrypt-rule', name),
+  batchAutoEncrypt: () => ipcRenderer.invoke('batch-auto-encrypt'),
+
   // v0.32.0: 快捷键模板系统
   hotkeyGetAllSlots: () => ipcRenderer.invoke('hotkey-get-all-slots'),
   hotkeyBind: (slot, label, content, isTemplate) => ipcRenderer.invoke('hotkey-bind', { slot, label, content, isTemplate }),

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -190,6 +190,8 @@
         if (tab.dataset.tab === 'hotkeys') loadHotkeySlots();
         // v0.37.0: 切换到关于 tab 时加载诊断信息
         if (tab.dataset.tab === 'about') loadDiagnostics();
+        // v0.45.0: 切换到自动加密 tab 时加载规则
+        if (tab.dataset.tab === 'autoEncrypt') loadAutoEncryptSettings();
       });
     });
 
@@ -3478,6 +3480,110 @@
       });
     }
   }
+
+  // ==================== v0.45.0: 自动加密规则 ====================
+
+  async function loadAutoEncryptSettings() {
+    try {
+      const settings = await window.electronAPI.getAutoEncryptSettings();
+      if (!settings) return;
+      $('#settingAutoEncrypt').checked = settings.enabled;
+      renderBuiltinRules(settings.builtinRules || []);
+      renderCustomRules(settings.customRules || []);
+    } catch (err) {
+      console.error('loadAutoEncryptSettings error:', err);
+    }
+  }
+
+  function renderBuiltinRules(rules) {
+    const container = $('#autoEncryptBuiltinRules');
+    container.innerHTML = '';
+    rules.forEach(rule => {
+      const item = document.createElement('div');
+      item.className = 'setting-item';
+      item.style.cssText = 'flex-direction:row;align-items:center;justify-content:space-between';
+      item.innerHTML = `
+        <div>
+          <label style="margin:0">
+            <input type="checkbox" data-builtin-type="${rule.type}" class="builtin-encrypt-toggle" ${rule.enabled ? 'checked' : ''}>
+            ${rule.name}
+          </label>
+          <small style="color:var(--muted);display:block;margin-left:1.5rem">${rule.description}</small>
+        </div>
+      `;
+      container.appendChild(item);
+    });
+    container.querySelectorAll('.builtin-encrypt-toggle').forEach(cb => {
+      cb.addEventListener('change', async () => {
+        await window.electronAPI.toggleAutoEncryptRule(cb.dataset.builtinType, cb.checked);
+        showToast(cb.checked ? '✅ 已启用' : '❌ 已禁用', 'success');
+      });
+    });
+  }
+
+  function renderCustomRules(rules) {
+    const container = $('#autoEncryptCustomRules');
+    container.innerHTML = '';
+    if (rules.length === 0) {
+      container.innerHTML = '<small style="color:var(--muted)">暂无自定义规则</small>';
+      return;
+    }
+    rules.forEach(rule => {
+      const item = document.createElement('div');
+      item.className = 'setting-item';
+      item.style.cssText = 'flex-direction:row;align-items:center;justify-content:space-between';
+      item.innerHTML = `
+        <div>
+          <strong>${rule.name}</strong>
+          <small style="color:var(--muted);display:block;margin-left:0.5rem;font-family:monospace">${rule.pattern}</small>
+        </div>
+        <button class="btn-danger btn-sm" data-rule-name="${rule.name}" style="padding:0.2rem 0.5rem;font-size:0.75rem">删除</button>
+      `;
+      container.appendChild(item);
+    });
+    container.querySelectorAll('.btn-danger[data-rule-name]').forEach(btn => {
+      btn.addEventListener('click', async () => {
+        await window.electronAPI.removeCustomAutoEncryptRule(btn.dataset.ruleName);
+        showToast('🗑️ 已删除规则', 'success');
+        loadAutoEncryptSettings();
+      });
+    });
+  }
+
+  $('#settingAutoEncrypt').addEventListener('change', async () => {
+    await window.electronAPI.setAutoEncryptEnabled($('#settingAutoEncrypt').checked);
+    showToast($('#settingAutoEncrypt').checked ? '🔐 自动加密已启用' : '🔓 自动加密已禁用', 'success');
+  });
+
+  $('#btnAddAutoEncryptRule').addEventListener('click', async () => {
+    const name = $('#customRuleName').value.trim();
+    const pattern = $('#customRulePattern').value.trim();
+    if (!name || !pattern) {
+      showToast('请填写规则名称和正则表达式', 'error');
+      return;
+    }
+    try {
+      new RegExp(pattern);
+    } catch (e) {
+      showToast('正则表达式无效：' + e.message, 'error');
+      return;
+    }
+    await window.electronAPI.addCustomAutoEncryptRule(name, pattern);
+    $('#customRuleName').value = '';
+    $('#customRulePattern').value = '';
+    showToast('✅ 规则已添加', 'success');
+    loadAutoEncryptSettings();
+  });
+
+  $('#btnBatchAutoEncrypt').addEventListener('click', async () => {
+    const result = await window.electronAPI.batchAutoEncrypt();
+    if (result.success) {
+      $('#batchEncryptResult').innerHTML = `<small style="color:var(--success)">✅ 加密 ${result.encryptedCount} 条，跳过 ${result.skippedCount} 条</small>`;
+      showToast(`✅ 批量加密完成：${result.encryptedCount} 条`, 'success');
+    } else {
+      $('#batchEncryptResult').innerHTML = `<small style="color:var(--danger)">❌ ${result.message}</small>`;
+    }
+  });
 
   // ==================== 启动 ====================
   document.addEventListener('DOMContentLoaded', init);

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -407,6 +407,7 @@
         <button class="settings-tab" data-tab="expiry">🗑️ 数据管理</button>
         <button class="settings-tab" data-tab="importExport">📥 导入导出</button>
         <button class="settings-tab" data-tab="hotkeys">⚡ 快捷模板</button>
+        <button class="settings-tab" data-tab="autoEncrypt">🔐 自动加密</button>
         <button class="settings-tab" data-tab="about">ℹ️ 关于</button>
       </div>
       <div class="settings-body">
@@ -607,12 +608,37 @@
             💡 支持模板变量：<code>{{date}}</code> 日期、<code>{{time}}</code> 时间、<code>{{datetime}}</code> 日期时间、<code>{{clipboard}}</code> 当前剪贴板
           </div>
         </div>
+        <!-- v0.45.0: 自动加密规则 -->
+        <div class="settings-tab-content" id="settingsAutoEncrypt" style="display:none">
+          <div class="setting-item">
+            <label>
+              <input type="checkbox" id="settingAutoEncrypt" checked>
+              🔐 启用自动加密
+            </label>
+            <small style="color:var(--muted)">检测到敏感内容时自动加密存储（需先设置加密密码）</small>
+          </div>
+          <div class="setting-section-title">内置规则</div>
+          <div id="autoEncryptBuiltinRules" style="display:flex;flex-direction:column;gap:0.5rem"></div>
+          <div class="setting-section-title" style="margin-top:1rem">自定义规则</div>
+          <div id="autoEncryptCustomRules" style="display:flex;flex-direction:column;gap:0.5rem"></div>
+          <div style="display:flex;gap:0.5rem;margin-top:0.75rem">
+            <input type="text" id="customRuleName" placeholder="规则名称（如：工号）" style="flex:1;padding:0.4rem 0.6rem;border-radius:6px;border:1px solid var(--border);background:var(--input-bg);color:var(--text)">
+            <input type="text" id="customRulePattern" placeholder="正则表达式（如 \d{6,8}）" style="flex:1.5;padding:0.4rem 0.6rem;border-radius:6px;border:1px solid var(--border);background:var(--input-bg);color:var(--text)">
+            <button class="btn-secondary" id="btnAddAutoEncryptRule">添加</button>
+          </div>
+          <div class="setting-item" style="margin-top:1rem">
+            <label>📦 批量加密</label>
+            <button class="btn-secondary" id="btnBatchAutoEncrypt">扫描并加密历史记录</button>
+            <small style="color:var(--muted)">对现有历史记录中匹配规则的未加密内容执行加密</small>
+            <div id="batchEncryptResult" style="margin-top:0.5rem"></div>
+          </div>
+        </div>
         <!-- v0.37.0: 关于 & 诊断 -->
         <div class="settings-tab-content" id="settingsAbout" style="display:none">
           <div class="about-header" style="text-align:center;padding:1.5rem 0">
             <div style="font-size:2.5rem">📋</div>
             <h3 style="margin:0.5rem 0 0.2rem;font-size:1.3rem">ClawBoard</h3>
-            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.44.0</div>
+            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.45.0</div>
           </div>
           <div class="diagnostics-box" style="background:var(--surface2);border-radius:10px;padding:1rem;font-size:0.82rem;line-height:1.8">
             <div id="diagnosticsInfo">加载中…</div>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -160,3 +160,7 @@
 /* v0.40.0: OCR 匹配标记 */
 .ocr-match-badge{display:inline-block;font-size:0.65rem;padding:1px 5px;border-radius:3px;background:rgba(99,102,241,0.2);color:#818CF8;margin-left:4px;cursor:help;vertical-align:middle}
 .ocr-search-hint{font-size:0.75rem;color:var(--muted);margin-top:4px;padding:3px 6px;background:rgba(99,102,241,0.06);border-radius:4px;line-height:1.4;max-height:40px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+/* v0.45.0: 自动加密规则 */
+.setting-section-title{font-size:0.85rem;font-weight:600;color:var(--text);margin:1rem 0 0.5rem;padding-bottom:0.3rem;border-bottom:1px solid var(--border)}
+.btn-sm{padding:0.2rem 0.5rem;font-size:0.75rem;border-radius:4px;cursor:pointer;border:none;transition:all 0.15s}


### PR DESCRIPTION
基于 Issue #94 实现。

新增功能：
- 自动加密规则配置面板（设置中「🔐 自动加密」标签页）
- 内置规则：信用卡号/身份证号/API密钥自动检测加密
- 自定义规则：用户可添加正则表达式匹配规则
- 批量加密：一键扫描历史记录执行加密

技术实现：
- ignore-rules.js: patterns 增加 action 字段，新增 autoEncrypt 配置
- database.js: records 表新增 sensitive_types 列
- clipboard.js: _handleText 集成自动加密
- main.js: 新增 6 个 IPC handlers
- preload.js + renderer: 完整 UI

Closes #94