### PR TITLE
feat: 悬浮预览弹窗 v0.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawboard",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "🧠 AI驱动的本地剪贴板管理器 - 智能记录、语义搜索、永久收藏",
   "main": "src/main.js",
   "scripts": {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -58,6 +58,7 @@
     initAboutPanel();         // v0.37.0: 初始化关于面板
     loadSearchHistory();      // v0.35.0: 加载搜索历史
     initSearchHistoryUI();    // v0.35.0: 初始化搜索历史下拉
+    loadHoverPreviewSettings(); // v0.46.0: 加载悬浮预览设置
     await loadGroups();
     await loadRecords();
     await loadStats();
@@ -1921,6 +1922,16 @@
       await loadRecords();
     });
 
+    // v0.46.0: 悬浮预览
+    card.addEventListener('mouseenter', () => {
+      if (!_hoverPreviewEnabled || isMultiSelectMode) return;
+      _hoverTimer = setTimeout(() => showHoverPreview(record, card), _hoverDelay);
+    });
+    card.addEventListener('mouseleave', () => {
+      clearTimeout(_hoverTimer);
+      hideHoverPreview();
+    });
+
     return card;
   }
 
@@ -3581,8 +3592,93 @@
       $('#batchEncryptResult').innerHTML = `<small style="color:var(--success)">✅ 加密 ${result.encryptedCount} 条，跳过 ${result.skippedCount} 条</small>`;
       showToast(`✅ 批量加密完成：${result.encryptedCount} 条`, 'success');
     } else {
-      $('#batchEncryptResult').innerHTML = `<small style="color:var(--danger)">❌ ${result.message}</small>`;
+      $('#batchEncryptResult').innerHTML = `<small style="color:var(--danger)">❌ ${result.message}</small>``;
     }
+  });
+
+  // ==================== v0.46.0: 悬浮预览弹窗 ====================
+
+  let _hoverPreviewEnabled = true;
+  let _hoverDelay = 400;
+  let _hoverTimer = null;
+  let _hoverPreviewVisible = false;
+
+  function showHoverPreview(record, cardEl) {
+    const preview = $('#hoverPreview');
+    const typeEl = $('#hoverPreviewType');
+    const metaEl = $('#hoverPreviewMeta');
+    const bodyEl = $('#hoverPreviewBody');
+
+    const typeLabels = { text: '📝 文字', code: '💻 代码', file: '📁 文件', image: '🖼️ 图片' };
+    typeEl.textContent = typeLabels[record.type] || '📋';
+    const charCount = (record.content || '').length;
+    metaEl.textContent = `${formatTimeAgo(new Date(record.created_at))} · ${charCount} 字符`;
+
+    if (record.encrypted) {
+      bodyEl.textContent = '🔒 内容已加密';
+      bodyEl.className = 'hover-preview-body';
+    } else if (record.type === 'image') {
+      bodyEl.innerHTML = `<img src="file://${record.content}" alt="图片">`;
+      bodyEl.className = 'hover-preview-body';
+    } else if (record.type === 'code') {
+      bodyEl.textContent = record.content || record.summary || '';
+      bodyEl.className = 'hover-preview-body code-preview';
+    } else {
+      bodyEl.textContent = record.content || record.summary || '';
+      bodyEl.className = 'hover-preview-body';
+    }
+
+    preview.style.display = 'block';
+    positionHoverPreview(cardEl);
+    requestAnimationFrame(() => preview.classList.add('show'));
+    _hoverPreviewVisible = true;
+  }
+
+  function hideHoverPreview() {
+    const preview = $('#hoverPreview');
+    preview.classList.remove('show');
+    _hoverPreviewVisible = false;
+    setTimeout(() => {
+      if (!_hoverPreviewVisible) preview.style.display = 'none';
+    }, 150);
+  }
+
+  function positionHoverPreview(cardEl) {
+    const preview = $('#hoverPreview');
+    const rect = cardEl.getBoundingClientRect();
+    const pW = 380, pH = 300;
+    let left = rect.right + 8;
+    let top = rect.top;
+    if (left + pW > window.innerWidth) {
+      left = rect.left - pW - 8;
+    }
+    if (left < 4) left = 4;
+    if (top + pH > window.innerHeight) {
+      top = window.innerHeight - pH - 8;
+    }
+    if (top < 4) top = 4;
+    preview.style.left = left + 'px';
+    preview.style.top = top + 'px';
+  }
+
+  function loadHoverPreviewSettings() {
+    const enabled = localStorage.getItem('hoverPreview') !== 'false';
+    const delay = parseInt(localStorage.getItem('hoverDelay') || '400', 10);
+    _hoverPreviewEnabled = enabled;
+    _hoverDelay = Math.max(100, Math.min(2000, delay));
+    $('#settingHoverPreview').checked = enabled;
+    $('#settingHoverDelay').value = _hoverDelay;
+  }
+
+  $('#settingHoverPreview').addEventListener('change', () => {
+    _hoverPreviewEnabled = $('#settingHoverPreview').checked;
+    localStorage.setItem('hoverPreview', _hoverPreviewEnabled);
+  });
+
+  $('#settingHoverDelay').addEventListener('change', () => {
+    _hoverDelay = Math.max(100, Math.min(2000, parseInt($('#settingHoverDelay').value, 10) || 400));
+    $('#settingHoverDelay').value = _hoverDelay;
+    localStorage.setItem('hoverDelay', _hoverDelay);
   });
 
   // ==================== 启动 ====================

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -429,6 +429,17 @@
           </div>
           <div class="setting-item">
             <label>
+              <input type="checkbox" id="settingHoverPreview" checked>
+              👁️ 悬浮预览弹窗
+            </label>
+            <small style="color:var(--muted)">鼠标悬浮条目时显示完整内容预览</small>
+          </div>
+          <div class="setting-item">
+            <label>⏱️ 预览延迟 (ms)</label>
+            <input type="number" id="settingHoverDelay" min="100" max="2000" value="400" step="100">
+          </div>
+          <div class="setting-item">
+            <label>
               <input type="checkbox" id="settingStartWithSystem">
               开机自启动
             </label>
@@ -638,7 +649,7 @@
           <div class="about-header" style="text-align:center;padding:1.5rem 0">
             <div style="font-size:2.5rem">📋</div>
             <h3 style="margin:0.5rem 0 0.2rem;font-size:1.3rem">ClawBoard</h3>
-            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.45.0</div>
+            <div id="aboutVersion" style="color:var(--muted);font-size:0.9rem">v0.46.0</div>
           </div>
           <div class="diagnostics-box" style="background:var(--surface2);border-radius:10px;padding:1rem;font-size:0.82rem;line-height:1.8">
             <div id="diagnosticsInfo">加载中…</div>
@@ -903,6 +914,15 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <!-- v0.46.0: 悬浮预览弹窗 -->
+  <div class="hover-preview" id="hoverPreview" style="display:none">
+    <div class="hover-preview-header">
+      <span class="hover-preview-type" id="hoverPreviewType"></span>
+      <span class="hover-preview-meta" id="hoverPreviewMeta"></span>
+    </div>
+    <div class="hover-preview-body" id="hoverPreviewBody"></div>
   </div>
 
   <script src="app.js"></script>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -164,3 +164,11 @@
 /* v0.45.0: 自动加密规则 */
 .setting-section-title{font-size:0.85rem;font-weight:600;color:var(--text);margin:1rem 0 0.5rem;padding-bottom:0.3rem;border-bottom:1px solid var(--border)}
 .btn-sm{padding:0.2rem 0.5rem;font-size:0.75rem;border-radius:4px;cursor:pointer;border:none;transition:all 0.15s}
+
+/* v0.46.0: 悬浮预览弹窗 */
+.hover-preview{position:fixed;z-index:10000;max-width:420px;min-width:200px;max-height:360px;background:var(--surface);border:1px solid var(--border);border-radius:8px;box-shadow:0 8px 32px rgba(0,0,0,0.35);pointer-events:none;opacity:0;transform:translateY(4px);transition:opacity 0.15s,transform 0.15s;overflow:hidden}
+.hover-preview.show{opacity:1;transform:translateY(0)}
+.hover-preview-header{display:flex;align-items:center;justify-content:space-between;padding:0.4rem 0.6rem;border-bottom:1px solid var(--border);font-size:0.75rem;color:var(--muted)}
+.hover-preview-body{padding:0.6rem;font-size:0.85rem;line-height:1.5;color:var(--text);max-height:300px;overflow:auto;word-break:break-word;white-space:pre-wrap}
+.hover-preview-body.code-preview{font-family:'Cascadia Code','Fira Code',Consolas,monospace;font-size:0.8rem;background:var(--surface2);padding:0.8rem}
+.hover-preview-body img{max-width:100%;max-height:280px;border-radius:4px;object-fit:contain}


### PR DESCRIPTION
基于 Issue #108 实现。

鼠标悬浮在剪贴板条目上时显示完整内容预览弹窗：
- 悬浮 400ms（可配置）后显示预览
- 自动定位，避免超出屏幕边界
- 长文本/代码保持格式，支持滚动
- 图片缩略预览
- 加密内容显示锁标记
- 设置面板控制开关和延迟时间
- 多选模式下自动禁用

Closes #108