### PR TITLE
feat: 快速粘贴浮动菜单 v0.57.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "clawboard",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "AI驱动的本地剪贴板管理器 - 智能记录、语义搜索、永久收藏",
   "main": "src/main.js",
   "scripts": {

--- a/src/database.js
+++ b/src/database.js
@@ -460,6 +460,35 @@ class Database {
     return result[0].values.map(row => this._rowToRecord(result[0].columns, row));
   }
 
+  // v0.57.0: 快速粘贴搜索方法
+  searchRecords(options = {}) {
+    const limit = options.limit || 30;
+    const search = options.search;
+    try {
+      let result;
+      if (search) {
+        result = this.db.exec(
+          `SELECT id, type, content, created_at FROM records WHERE content LIKE ? ORDER BY created_at DESC LIMIT ?`,
+          [`%${search}%`, limit]
+        );
+      } else {
+        result = this.db.exec(
+          `SELECT id, type, content, created_at FROM records ORDER BY created_at DESC LIMIT ?`,
+          [limit]
+        );
+      }
+      if (result.length === 0 || result[0].values.length === 0) return [];
+      return result[0].values.map(row => {
+        const rec = {};
+        result[0].columns.forEach((col, i) => { rec[col] = row[i]; });
+        return rec;
+      });
+    } catch (e) {
+      console.error('searchRecords error:', e);
+      return [];
+    }
+  }
+
   // 获取来源应用列表及其记录数
   getSourceApps() {
     const result = this.db.exec(`

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ const TextTransform = require('./text-transform'); // v0.33.0 格式转换
 
 let mainWindow = null;
 let cycleWindow = null; // v0.39.0: Cycle mode window
+let quickPasteWindow = null; // v0.57.0: Quick paste floating menu
 let tray = null;
 let db = null;
 let clipboardWatcher = null;
@@ -143,6 +144,56 @@ function createCycleWindow() {
   });
 
   return cycleWindow;
+}
+
+// v0.57.0: Quick paste floating window
+function createQuickPasteWindow() {
+  if (quickPasteWindow && !quickPasteWindow.isDestroyed()) {
+    quickPasteWindow.close();
+    quickPasteWindow = null;
+  }
+
+  const { screen } = require('electron');
+  const cursorPos = screen.getCursorScreenPoint();
+  const display = screen.getDisplayNearestPoint(cursorPos);
+  const b = display.workArea;
+  const w = 380, h = 400;
+  let x = cursorPos.x + 10;
+  let y = cursorPos.y + 10;
+  if (x + w > b.x + b.width) x = b.x + b.width - w - 10;
+  if (y + h > b.y + b.height) y = b.y + b.height - h - 10;
+  if (x < b.x) x = b.x + 10;
+  if (y < b.y) y = b.y + 10;
+
+  quickPasteWindow = new BrowserWindow({
+    width: w, height: h, x, y,
+    frame: false, transparent: true, resizable: false,
+    skipTaskbar: true, alwaysOnTop: true, show: false,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+    },
+  });
+
+  quickPasteWindow.loadFile(path.join(__dirname, 'quick-paste.html'));
+
+  // Send recent records after load
+  quickPasteWindow.webContents.on('did-finish-load', () => {
+    const recent = db.searchRecords({ limit: 30 });
+    quickPasteWindow.webContents.send('quick-paste-data', recent.map(r => ({
+      id: r.id, type: r.type, content: r.content ? r.content.substring(0, 200) : ''
+    })));
+  });
+
+  quickPasteWindow.once('ready-to-show', () => quickPasteWindow.show());
+  quickPasteWindow.on('blur', () => {
+    if (quickPasteWindow && !quickPasteWindow.isDestroyed()) quickPasteWindow.close();
+  });
+  quickPasteWindow.on('closed', () => { quickPasteWindow = null; });
+
+  return quickPasteWindow;
 }
 
 function createWindow() {
@@ -1266,6 +1317,9 @@ app.whenReady().then(async () => {
   // v0.39.0: 注册循环模式快捷键
   registerCycleShortcut();
 
+  // v0.57.0: 注册快速粘贴浮动菜单快捷键
+  registerQuickPasteShortcut();
+
   // 注册 IPC
   setupIPC();
 
@@ -1605,6 +1659,28 @@ function registerCycleShortcut() {
   } else {
     log.info('循环模式快捷键 ' + shortcut + ' 已注册');
     cycleShortcut = shortcut;
+  }
+}
+
+// v0.57.0: Register quick paste shortcut (Alt+Q)
+let quickPasteShortcut = null;
+function registerQuickPasteShortcut() {
+  if (quickPasteShortcut) {
+    globalShortcut.unregister(quickPasteShortcut);
+  }
+  const shortcut = 'Alt+Q';
+  try {
+    const ret = globalShortcut.register(shortcut, () => {
+      createQuickPasteWindow();
+    });
+    if (!ret) {
+      log.warn('快速粘贴快捷键注册失败: ' + shortcut);
+    } else {
+      log.info('快速粘贴快捷键 ' + shortcut + ' 已注册');
+      quickPasteShortcut = shortcut;
+    }
+  } catch (e) {
+    log.warn('快速粘贴快捷键注册失败:', e);
   }
 }
 
@@ -2327,6 +2403,24 @@ ipcMain.on('cycle-cancel', () => {
   if (cycleWindow && !cycleWindow.isDestroyed()) {
     cycleWindow.close();
   }
+});
+
+// v0.57.0: Quick paste IPC handlers
+ipcMain.on('quick-paste-select', (event, item) => {
+  if (quickPasteWindow && !quickPasteWindow.isDestroyed()) quickPasteWindow.close();
+  const record = db.getRecord(item.id);
+  if (record && record.content) {
+    clipboard.writeText(record.content);
+    // Simulate Ctrl+V paste
+    setTimeout(() => {
+      const { exec } = require('child_process');
+      exec('powershell -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait(\"^v\")"');
+    }, 100);
+  }
+});
+
+ipcMain.on('quick-paste-close', () => {
+  if (quickPasteWindow && !quickPasteWindow.isDestroyed()) quickPasteWindow.close();
 });
 
 // ==================== v0.48.0: 快捷片段 ====================

--- a/src/quick-paste.html
+++ b/src/quick-paste.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline';">
+  <title>Quick Paste</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Segoe UI', sans-serif; background: rgba(30,30,40,0.95); color: #e0e0e0; border-radius: 8px; overflow: hidden; }
+    .quick-paste-list { max-height: 360px; overflow-y: auto; }
+    .quick-paste-item { padding: 8px 12px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.06); display: flex; align-items: center; gap: 8px; font-size: 13px; }
+    .quick-paste-item:hover { background: rgba(59,130,246,0.2); }
+    .quick-paste-item .type-icon { font-size: 14px; flex-shrink: 0; }
+    .quick-paste-item .preview { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; }
+    .quick-paste-item .shortcut { color: rgba(255,255,255,0.3); font-size: 11px; flex-shrink: 0; }
+    .search-bar { padding: 8px 12px; border-bottom: 1px solid rgba(255,255,255,0.1); }
+    .search-bar input { width: 100%; background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1); border-radius: 4px; padding: 6px 8px; color: #e0e0e0; font-size: 13px; outline: none; }
+    .search-bar input:focus { border-color: #3b82f6; }
+    .empty-hint { padding: 20px; text-align: center; color: rgba(255,255,255,0.3); font-size: 13px; }
+  </style>
+</head>
+<body>
+  <div class="search-bar"><input type="text" id="searchInput" placeholder="搜索..." autofocus></div>
+  <div class="quick-paste-list" id="itemList"></div>
+  <script>
+    const { ipcRenderer } = require('electron');
+    let items = [];
+    let filtered = [];
+
+    ipcRenderer.on('quick-paste-data', (_, data) => {
+      items = data;
+      filtered = data;
+      render();
+    });
+
+    document.getElementById('searchInput').addEventListener('input', (e) => {
+      const q = e.target.value.toLowerCase();
+      filtered = q ? items.filter(i => (i.content || '').toLowerCase().includes(q)) : items;
+      render();
+    });
+
+    function render() {
+      const list = document.getElementById('itemList');
+      if (filtered.length === 0) {
+        list.innerHTML = '<div class="empty-hint">无匹配记录</div>';
+        return;
+      }
+      list.innerHTML = filtered.slice(0, 15).map((item, i) => {
+        const icon = { text: '📝', code: '💻', file: '📁', image: '🖼️' }[item.type] || '📋';
+        const preview = (item.content || '').substring(0, 80).replace(/\n/g, ' ');
+        const shortcut = i < 9 ? `${i + 1}` : '';
+        return `<div class="quick-paste-item" data-index="${i}" tabindex="0"><span class="type-icon">${icon}</span><span class="preview">${escapeHtml(preview)}</span>${shortcut ? `<span class="shortcut">${shortcut}</span>` : ''}</div>`;
+      }).join('');
+
+      list.querySelectorAll('.quick-paste-item').forEach(el => {
+        el.addEventListener('click', () => selectItem(parseInt(el.dataset.index)));
+        el.addEventListener('keydown', (e) => { if (e.key === 'Enter') selectItem(parseInt(el.dataset.index)); });
+      });
+    }
+
+    function selectItem(index) {
+      const item = filtered[index];
+      if (item) ipcRenderer.send('quick-paste-select', item);
+    }
+
+    // Number key shortcuts
+    document.addEventListener('keydown', (e) => {
+      const num = parseInt(e.key);
+      if (num >= 1 && num <= 9 && num <= filtered.length) {
+        selectItem(num - 1);
+      }
+      if (e.key === 'Escape') ipcRenderer.send('quick-paste-close');
+    });
+
+    function escapeHtml(t) { const d = document.createElement('div'); d.textContent = t; return d.innerHTML; }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## ⚡ 快速粘贴浮动菜单 (v0.57.0)

Closes #126

### 新功能

- **浮动菜单** - Alt+Q 打开光标附近的剪贴板快速粘贴菜单
- **实时搜索** - 浮动菜单内搜索过滤剪贴板记录
- **数字快捷键** - 按 1-9 快速选择对应条目
- **一键粘贴** - 选中后自动复制并模拟 Ctrl+V 粘贴

### 文件变更

| 文件 | 变更 |
|------|------|
| src/quick-paste.html | 新增：浮动菜单页面 |
| src/main.js | 新增：窗口创建、IPC、全局快捷键 |
| src/database.js | 新增：getRecentRecords 方法 |
| package.json | 版本 0.56.0 → 0.57.0 |
| README.md | 更新日志 |