### PR TITLE
feat: 跨平台代码抽象 v0.60.0

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,7 @@ log.info('ClawBoard 启动...');
 // 模块
 const ClipboardWatcher = require('./clipboard');
 const Database = require('./database');
+const Platform = require('./platform'); // v0.60.0 跨平台抽象
 const AI = require('./ai');
 const OCRService = require('./ocr'); // v0.17.0 OCR服务
 const SmartPaste = require('./smart-paste'); // v0.31.0 智能粘贴
@@ -1497,21 +1498,21 @@ process.on('unhandledRejection', (reason) => {
 // v0.29.0: 播放通知声音
 function playNotificationSound() {
   try {
-    // 使用系统默认声音
     const { exec } = require('child_process');
-    if (process.platform === 'win32') {
-      // Windows: 使用 PowerShell 播放系统声音
-      exec('powershell -c "[System.Media.SystemSounds]::Beep.Play()"', { windowsHide: true });
-    } else if (process.platform === 'darwin') {
-      // macOS: 使用 afplay
-      exec('afplay /System/Library/Sounds/Glass.aiff');
-    } else {
-      // Linux: 使用 canberra-gtk-play 或 paplay
-      exec('canberra-gtk-play -i message', (err) => {
-        if (err) {
-          exec('paplay /usr/share/sounds/freedesktop/stereo/message.oga', () => {});
-        }
-      });
+    const cmd = Platform.getNotificationSoundCommand();
+    if (cmd) {
+      if (Platform.isWindows) {
+        exec(cmd, { windowsHide: true });
+      } else if (Platform.isMac) {
+        exec(cmd);
+      } else {
+        // Linux: try canberra first, fallback to paplay
+        exec(cmd, (err) => {
+          if (err) {
+            exec('paplay /usr/share/sounds/freedesktop/stereo/message.oga', () => {});
+          }
+        });
+      }
     }
   } catch (err) {
     log.warn('播放通知声音失败:', err.message);

--- a/src/platform.js
+++ b/src/platform.js
@@ -1,0 +1,94 @@
+/**
+ * Platform detection and platform-specific utilities
+ * v0.60.0 - Cross-platform abstraction layer
+ */
+
+const path = require('path');
+const { app } = require('electron');
+const os = require('os');
+
+class Platform {
+  static get isWindows() { return process.platform === 'win32'; }
+  static get isMac() { return process.platform === 'darwin'; }
+  static get isLinux() { return process.platform === 'linux'; }
+
+  // Default terminal commands per platform
+  static get terminalCommands() {
+    if (this.isWindows) {
+      return {
+        open: 'start cmd /k',
+        openWT: 'wt.exe',
+        checkWT: 'where wt',
+        wtPrefix: 'wt -d',
+      };
+    }
+    if (this.isMac) {
+      return {
+        open: 'open -a Terminal',
+        openWT: null,
+        checkWT: null,
+        wtPrefix: 'open -a Terminal',
+      };
+    }
+    // Linux
+    return {
+      open: 'gnome-terminal',
+      openWT: null,
+      checkWT: null,
+      wtPrefix: 'gnome-terminal --working-directory=',
+    };
+  }
+
+  // File explorer commands per platform
+  static get fileExplorerCommands() {
+    if (this.isWindows) return { open: 'explorer', select: 'explorer /select,' };
+    if (this.isMac) return { open: 'open -R', select: 'open -R' };
+    // Linux
+    return { open: 'xdg-open', select: 'xdg-open' };
+  }
+
+  // Path to config directory
+  static getConfigDir() {
+    if (this.isWindows) return path.join(app.getPath('appData'), 'ClawBoard');
+    if (this.isMac) return path.join(app.getPath('home'), '.config', 'clawboard');
+    // Linux
+    return path.join(app.getPath('home'), '.config', 'clawboard');
+  }
+
+  // Default hotkey modifiers
+  static get metaKey() {
+    if (this.isWindows) return 'Ctrl';
+    if (this.isMac) return 'Command';
+    return 'Ctrl';
+  }
+
+  // Windows Terminal executable path
+  static getWindowsTerminalPath() {
+    if (!this.isWindows) return null;
+    return path.join(process.env.LOCALAPPDATA, 'Microsoft', 'WindowsApps', 'wt.exe');
+  }
+
+  // Play notification sound command
+  static getNotificationSoundCommand() {
+    if (this.isWindows) {
+      return 'powershell -c "[System.Media.SystemSounds]::Beep.Play()"';
+    }
+    if (this.isMac) {
+      return 'afplay /System/Library/Sounds/Glass.aiff';
+    }
+    // Linux
+    return 'canberra-gtk-play -i message';
+  }
+
+  // Quick paste Ctrl+V paste command (Windows only)
+  static getQuickPasteCommand() {
+    if (this.isWindows) {
+      return 'powershell -Command "Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.SendKeys]::SendWait(\'^v\')"';
+    }
+    // macOS: Cmd+V, Linux: Ctrl+Shift+V or custom
+    // Return null for non-Windows; implementers should handle per-platform
+    return null;
+  }
+}
+
+module.exports = Platform;


### PR DESCRIPTION
## 🌍 跨平台代码抽象 (v0.60.0)

Prepares for #93 — 为 macOS/Linux 适配做代码层面准备。

### 新功能

- **platform.js 模块** - 封装平台检测与平台特定命令
- **平台检测** - 支持 Windows/macOS/Linux 三大平台
- **条件执行** - 文件管理器、终端等操作根据平台使用不同命令
- **诊断信息** - 系统诊断中显示平台名称

### 文件变更

| 文件 | 变更 |
|------|------|
| src/platform.js | 新增：平台抽象模块 |
| src/main.js | 使用 Platform 模块替换硬编码平台判断 |
| README.md | 新增跨平台支持说明 |

### 备注

此版本为跨平台适配的准备工作，实际 macOS/Linux 测试仍需进行。