### PR TITLE
feat: 剪贴板统计与可视化 v0.61.0

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -2218,3 +2218,116 @@ Database.prototype.findSimilar = function(content, threshold = 0.8, limit = 5) {
 
   return similar.sort((a, b) => b.similarity - a.similarity).slice(0, limit);
 };
+
+// ==================== v0.61.0: 统计与可视化 ====================
+
+Database.prototype.getStatsByType = function() {
+  try {
+    const result = this.db.exec(`
+      SELECT type, COUNT(*) as count
+      FROM records
+      GROUP BY type
+      ORDER BY count DESC
+    `);
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(row => ({ type: row[0], count: row[1] }));
+  } catch (e) {
+    console.error('getStatsByType error:', e);
+    return [];
+  }
+};
+
+Database.prototype.getStatsByApp = function(limit) {
+  limit = limit || 10;
+  try {
+    const result = this.db.exec(`
+      SELECT source_app, COUNT(*) as count
+      FROM records
+      WHERE source_app IS NOT NULL AND source_app != ''
+      GROUP BY source_app
+      ORDER BY count DESC
+      LIMIT ${limit}
+    `);
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(row => ({ source_app: row[0], count: row[1] }));
+  } catch (e) {
+    console.error('getStatsByApp error:', e);
+    return [];
+  }
+};
+
+Database.prototype.getDailyStats = function(days) {
+  days = days || 30;
+  try {
+    const result = this.db.exec(`
+      SELECT
+        DATE(created_at) as date,
+        COUNT(*) as count,
+        SUM(CASE WHEN type='text' THEN 1 ELSE 0 END) as text_count,
+        SUM(CASE WHEN type='code' THEN 1 ELSE 0 END) as code_count,
+        SUM(CASE WHEN type='file' THEN 1 ELSE 0 END) as file_count,
+        SUM(CASE WHEN type='image' THEN 1 ELSE 0 END) as image_count
+      FROM records
+      WHERE created_at >= DATE('now', '-${days} days')
+      GROUP BY DATE(created_at)
+      ORDER BY date ASC
+    `);
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(row => ({
+      date: row[0],
+      count: row[1],
+      text_count: row[2],
+      code_count: row[3],
+      file_count: row[4],
+      image_count: row[5]
+    }));
+  } catch (e) {
+    console.error('getDailyStats error:', e);
+    return [];
+  }
+};
+
+Database.prototype.getHourlyStats = function() {
+  try {
+    const result = this.db.exec(`
+      SELECT
+        CAST(strftime('%H', created_at) AS INTEGER) as hour,
+        COUNT(*) as count
+      FROM records
+      WHERE created_at >= DATE('now', '-30 days')
+      GROUP BY hour
+      ORDER BY hour
+    `);
+    const hourly = Array(24).fill(0);
+    if (result.length > 0 && result[0].values.length > 0) {
+      result[0].values.forEach(row => { hourly[row[0]] = row[1]; });
+    }
+    return hourly;
+  } catch (e) {
+    console.error('getHourlyStats error:', e);
+    return Array(24).fill(0);
+  }
+};
+
+Database.prototype.getWeeklyTrend = function() {
+  try {
+    const result = this.db.exec(`
+      SELECT
+        strftime('%w', created_at) as weekday,
+        COUNT(*) as count
+      FROM records
+      WHERE created_at >= DATE('now', '-30 days')
+      GROUP BY weekday
+      ORDER BY weekday
+    `);
+    const dayNames = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(row => ({
+      day: dayNames[parseInt(row[0])],
+      count: row[1]
+    }));
+  } catch (e) {
+    console.error('getWeeklyTrend error:', e);
+    return [];
+  }
+};

--- a/src/main.js
+++ b/src/main.js
@@ -439,6 +439,27 @@ function setupIPC() {
     }
   });
 
+  // v0.61.0: 统计与可视化
+  ipcMain.handle('get-stats-by-type', async () => {
+    try { return db.getStatsByType(); } catch (e) { log.error('get-stats-by-type error:', e); return []; }
+  });
+
+  ipcMain.handle('get-stats-by-app', async (_, limit) => {
+    try { return db.getStatsByApp(limit || 10); } catch (e) { log.error('get-stats-by-app error:', e); return []; }
+  });
+
+  ipcMain.handle('get-daily-stats', async (_, days) => {
+    try { return db.getDailyStats(days || 30); } catch (e) { log.error('get-daily-stats error:', e); return []; }
+  });
+
+  ipcMain.handle('get-hourly-stats', async () => {
+    try { return db.getHourlyStats(); } catch (e) { log.error('get-hourly-stats error:', e); return Array(24).fill(0); }
+  });
+
+  ipcMain.handle('get-weekly-trend', async () => {
+    try { return db.getWeeklyTrend(); } catch (e) { log.error('get-weekly-trend error:', e); return []; }
+  });
+
   // 获取系统健康状态 (v0.26.0)
   ipcMain.handle('get-system-health', async () => {
     try {

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,6 +18,12 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
   getStats: () => ipcRenderer.invoke('get-stats'),
   getDetailedStats: () => ipcRenderer.invoke('get-detailed-stats'),
+  // v0.61.0: 统计与可视化
+  getStatsByType: () => ipcRenderer.invoke('get-stats-by-type'),
+  getStatsByApp: (limit) => ipcRenderer.invoke('get-stats-by-app', limit),
+  getDailyStats: (days) => ipcRenderer.invoke('get-daily-stats', days),
+  getHourlyStats: () => ipcRenderer.invoke('get-hourly-stats'),
+  getWeeklyTrend: () => ipcRenderer.invoke('get-weekly-trend'),
   getSourceApps: () => ipcRenderer.invoke('get-source-apps'),
   getAllTags: () => ipcRenderer.invoke('get-all-tags'),
   addTag: (recordId, tag) => ipcRenderer.invoke('add-tag', { recordId, tag }),


### PR DESCRIPTION
## 📊 剪贴板统计与可视化 (v0.61.0)

Closes #132

### 新功能

- **统计面板** - 设置中新增「统计」标签页
- **每日趋势图** - Chart.js 折线图展示最近 7/30/90 天剪贴趋势
- **类型分布图** - 饼图展示文字/代码/文件/图片占比
- **24小时热力图** - 柱状图展示每日各时段活跃度
- **来源应用统计** - 横向条形图展示 Top 10 剪贴来源应用

### 文件变更

| 文件 | 变更 |
|------|------|
| src/database.js | 新增 4 个统计查询方法 |
| src/main.js | 新增 4 个 IPC handler |
| src/preload.js | 新增统计 API |
| src/renderer/index.html | 新增统计标签页 UI |
| src/renderer/app.js | 新增图表渲染逻辑 |
| src/renderer/styles.css | 统计面板样式 |
| package.json | 版本 0.60.0 → 0.61.0 |
| README.md | 更新日志 |