### PR TITLE
feat: 回收站功能 v0.72.0 (#156)

### DIFF
--- a/src/database.js
+++ b/src/database.js
@@ -190,6 +190,34 @@ class Database {
       )
     `);
 
+    // v0.72.0: 回收站表
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS trash (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        original_id INTEGER NOT NULL,
+        type TEXT NOT NULL DEFAULT 'text',
+        content TEXT NOT NULL,
+        summary TEXT,
+        source TEXT DEFAULT 'clipboard',
+        source_app TEXT,
+        source_title TEXT,
+        source_url TEXT,
+        favorite INTEGER DEFAULT 0,
+        tags TEXT DEFAULT '[]',
+        ai_summary TEXT,
+        embedding BLOB,
+        language TEXT,
+        locked INTEGER DEFAULT 0,
+        encrypted INTEGER DEFAULT 0,
+        synced INTEGER DEFAULT 0,
+        ocr_text TEXT,
+        merged_from TEXT,
+        is_merged INTEGER DEFAULT 0,
+        sensitive_types TEXT DEFAULT '',
+        deleted_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
     this._save();
   }
 
@@ -771,11 +799,101 @@ class Database {
     return this.getRecord(id);
   }
 
-  // 删除记录
-  deleteRecord(id) {
+  // v0.72.0: 软删除记录（移入回收站）
+  deleteRecord(id, permanent = false) {
+    if (permanent) {
+      this.db.run(`DELETE FROM records WHERE id = ?`, [id]);
+      this._save();
+      return true;
+    }
+    // 软删除：复制到回收站
+    const record = this.getRecord(id);
+    if (!record) return false;
+    this.db.run(`
+      INSERT INTO trash (original_id, type, content, summary, source, source_app, source_title, source_url,
+        favorite, tags, ai_summary, embedding, language, locked, encrypted, synced, ocr_text, merged_from, is_merged, sensitive_types)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [id, record.type, record.content, record.summary, record.source, record.source_app, record.source_title,
+        record.source_url, record.favorite, record.tags, record.ai_summary, record.embedding,
+        record.language, record.locked, record.encrypted, record.synced, record.ocr_text,
+        record.merged_from, record.is_merged, record.sensitive_types]
+    );
     this.db.run(`DELETE FROM records WHERE id = ?`, [id]);
     this._save();
     return true;
+  }
+
+  // v0.72.0: 永久删除单条回收站记录
+  deleteTrashRecord(id) {
+    this.db.run(`DELETE FROM trash WHERE id = ?`, [id]);
+    this._save();
+    return true;
+  }
+
+  // v0.72.0: 清空回收站
+  emptyTrash() {
+    this.db.run(`DELETE FROM trash`);
+    this._save();
+    return true;
+  }
+
+  // v0.72.0: 恢复回收站记录
+  restoreFromTrash(trashId) {
+    const trashRecord = this.getTrashRecord(trashId);
+    if (!trashRecord) return false;
+    this.db.run(`
+      INSERT INTO records (type, content, summary, source, source_app, source_title, source_url,
+        favorite, tags, ai_summary, embedding, language, locked, encrypted, synced, ocr_text, merged_from, is_merged, sensitive_types)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+      [trashRecord.type, trashRecord.content, trashRecord.summary, trashRecord.source, trashRecord.source_app,
+        trashRecord.source_title, trashRecord.source_url, trashRecord.favorite, trashRecord.tags,
+        trashRecord.ai_summary, trashRecord.embedding, trashRecord.language, trashRecord.locked,
+        trashRecord.encrypted, trashRecord.synced, trashRecord.ocr_text, trashRecord.merged_from,
+        trashRecord.is_merged, trashRecord.sensitive_types]
+    );
+    this.db.run(`DELETE FROM trash WHERE id = ?`, [trashId]);
+    this._save();
+    return true;
+  }
+
+  // v0.72.0: 获取回收站单条记录
+  getTrashRecord(id) {
+    const result = this.db.exec(`SELECT * FROM trash WHERE id = ?`, [id]);
+    if (!result.length || !result[0].values.length) return null;
+    const cols = result[0].columns;
+    const row = result[0].values[0];
+    const record = {};
+    cols.forEach((c, i) => { record[c] = row[i]; });
+    return record;
+  }
+
+  // v0.72.0: 获取回收站列表
+  getTrashRecords(limit = 50, offset = 0) {
+    const result = this.db.exec(
+      `SELECT * FROM trash ORDER BY deleted_at DESC LIMIT ? OFFSET ?`,
+      [limit, offset]
+    );
+    if (!result.length) return [];
+    const cols = result[0].columns;
+    return result[0].values.map(row => {
+      const record = {};
+      cols.forEach((c, i) => { record[c] = row[i]; });
+      return record;
+    });
+  }
+
+  // v0.72.0: 获取回收站统计
+  getTrashStats() {
+    const total = this.db.exec(`SELECT COUNT(*) FROM trash`)[0]?.values[0][0] || 0;
+    return { total };
+  }
+
+  // v0.72.0: 自动清理过期回收站记录（30天）
+  autoCleanTrash() {
+    this.db.run(`DELETE FROM trash WHERE datetime(deleted_at) < datetime('now', '-30 days')`);
+    this._save();
   }
 
   // 清空历史

--- a/src/main.js
+++ b/src/main.js
@@ -447,14 +447,39 @@ function setupIPC() {
     }
   });
 
-  // 删除记录
-  ipcMain.handle('delete-record', async (event, id) => {
+  // v0.72.0: 删除记录（支持软删除/永久删除）
+  ipcMain.handle('delete-record', async (event, id, permanent = false) => {
     try {
-      return db.deleteRecord(id);
+      return db.deleteRecord(id, permanent);
     } catch (err) {
       log.error('delete-record error:', err);
       return false;
     }
+  });
+
+  // v0.72.0: 获取回收站列表
+  ipcMain.handle('get-trash-records', async (_, limit = 50, offset = 0) => {
+    try { return db.getTrashRecords(limit, offset); } catch (err) { log.error('get-trash-records error:', err); return []; }
+  });
+
+  // v0.72.0: 获取回收站统计
+  ipcMain.handle('get-trash-stats', async () => {
+    try { return db.getTrashStats(); } catch (err) { log.error('get-trash-stats error:', err); return { total: 0 }; }
+  });
+
+  // v0.72.0: 恢复回收站记录
+  ipcMain.handle('restore-from-trash', async (_, trashId) => {
+    try { return db.restoreFromTrash(trashId); } catch (err) { log.error('restore-from-trash error:', err); return false; }
+  });
+
+  // v0.72.0: 永久删除回收站记录
+  ipcMain.handle('delete-trash-record', async (_, trashId) => {
+    try { return db.deleteTrashRecord(trashId); } catch (err) { log.error('delete-trash-record error:', err); return false; }
+  });
+
+  // v0.72.0: 清空回收站
+  ipcMain.handle('empty-trash', async () => {
+    try { return db.emptyTrash(); } catch (err) { log.error('empty-trash error:', err); return false; }
   });
 
   // 清空历史
@@ -1714,6 +1739,8 @@ function startAutoExpiryTimer() {
           mainWindow.webContents.send('expiry-cleanup', { count });
         }
       }
+      // v0.72.0: 自动清理过期回收站记录
+      db.autoCleanTrash();
     } catch (err) {
       log.error('自动过期清理失败:', err);
     }
@@ -1722,6 +1749,8 @@ function startAutoExpiryTimer() {
   if (count > 0) {
     log.info('启动时自动过期清理: 删除了 ' + count + ' 条过期记录');
   }
+  // v0.72.0: 启动时清理过期回收站记录
+  db.autoCleanTrash();
 }
 
 function showClipboardNotification(record) {

--- a/src/preload.js
+++ b/src/preload.js
@@ -13,7 +13,7 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   toggleFavorite: (id) => ipcRenderer.invoke('toggle-favorite', id),
   updateNote: (id, note) => ipcRenderer.invoke('update-note', { id, note }),
   updateItemContent: (id, content) => ipcRenderer.invoke('update-item-content', { id, content }),
-  deleteRecord: (id) => ipcRenderer.invoke('delete-record', id),
+  deleteRecord: (id, permanent) => ipcRenderer.invoke('delete-record', id, permanent),
   clearHistory: () => ipcRenderer.invoke('clear-history'),
   copyToClipboard: (text) => ipcRenderer.invoke('copy-to-clipboard', text),
   getStats: () => ipcRenderer.invoke('get-stats'),
@@ -216,6 +216,13 @@ contextBridge.exposeInMainWorld('ClawBoard', {
   // v0.70.0: Storage compression
   getStorageStats: () => ipcRenderer.invoke('get-storage-stats'),
   compressAll: () => ipcRenderer.invoke('compress-all'),
+
+  // v0.72.0: 回收站
+  getTrashRecords: (limit, offset) => ipcRenderer.invoke('get-trash-records', limit, offset),
+  getTrashStats: () => ipcRenderer.invoke('get-trash-stats'),
+  restoreFromTrash: (trashId) => ipcRenderer.invoke('restore-from-trash', trashId),
+  deleteTrashRecord: (trashId) => ipcRenderer.invoke('delete-trash-record', trashId),
+  emptyTrash: () => ipcRenderer.invoke('empty-trash'),
 
   // 移除监听
   removeAllListeners: (channel) => {

--- a/src/renderer/app.js
+++ b/src/renderer/app.js
@@ -470,6 +470,26 @@
       await loadPinnedList();
     });
 
+    // v0.72.0: 回收站面板
+    $('#btnTrash').addEventListener('click', async () => {
+      $('#trashOverlay').classList.add('show');
+      await loadTrashPanel();
+    });
+    $('#btnCloseTrash').addEventListener('click', () => {
+      $('#trashOverlay').classList.remove('show');
+    });
+    $('#trashOverlay').addEventListener('click', (e) => {
+      if (e.target === $('#trashOverlay')) {
+        $('#trashOverlay').classList.remove('show');
+      }
+    });
+    $('#btnEmptyTrash').addEventListener('click', async () => {
+      if (!confirm('确定要清空回收站吗？此操作不可撤销！')) return;
+      await window.ClawBoard.emptyTrash();
+      showToast('🗑️ 回收站已清空', 'success');
+      await loadTrashPanel();
+    });
+
     // 云端同步面板 v0.28.0
     $('#btnCloudSync').addEventListener('click', async () => {
       $('#cloudSyncOverlay').classList.add('show');
@@ -1438,6 +1458,84 @@
       await loadPinnedList();
       await loadPinnedStats();
       showToast('已批量删除');
+    }
+  });
+
+  // v0.72.0: 回收站面板
+  async function loadTrashPanel() {
+    const trashLoading = document.getElementById('trashLoading');
+    const trashEmpty = document.getElementById('trashEmpty');
+    const trashList = document.getElementById('trashList');
+    const trashCount = document.getElementById('trashCount');
+
+    if (trashLoading) trashLoading.style.display = 'block';
+    if (trashEmpty) trashEmpty.style.display = 'none';
+
+    try {
+      const stats = await window.ClawBoard.getTrashStats();
+      if (trashCount) trashCount.textContent = stats.total || 0;
+
+      const records = await window.ClawBoard.getTrashRecords(100, 0);
+      if (trashLoading) trashLoading.style.display = 'none';
+
+      if (!records || records.length === 0) {
+        if (trashEmpty) trashEmpty.style.display = 'block';
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      records.forEach(r => {
+        const item = document.createElement('div');
+        item.className = 'trash-item';
+        const preview = (r.content || '').substring(0, 120);
+        const timeStr = r.deleted_at ? new Date(r.deleted_at).toLocaleString('zh-CN') : '';
+        item.innerHTML = `
+          <div class="trash-item-content">
+            <div class="trash-item-preview">${escapeHtml(preview)}${(r.content || '').length > 120 ? '...' : ''}</div>
+            <div class="trash-item-meta">
+              <span class="trash-item-type">${escapeHtml(r.type || 'text')}</span>
+              <span class="trash-item-time">删除于 ${escapeHtml(timeStr)}</span>
+            </div>
+          </div>
+          <div class="trash-item-actions">
+            <button class="batch-btn" data-action="restore" data-id="${r.id}" title="恢复">♻️ 恢复</button>
+            <button class="batch-btn danger" data-action="permanent-delete" data-id="${r.id}" title="永久删除">🗑️</button>
+          </div>
+        `;
+        fragment.appendChild(item);
+      });
+
+      // 移除旧的 trash items（保留 loading 和 empty）
+ trashList.querySelectorAll('.trash-item').forEach(el => el.remove());
+      trashList.appendChild(fragment);
+    } catch (e) {
+      console.error('Load trash panel failed:', e);
+      if (trashLoading) trashLoading.style.display = 'none';
+    }
+  }
+
+  // v0.72.0: 回收站事件委托
+  document.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-action]');
+    if (!btn) return;
+    const action = btn.dataset.action;
+    const id = parseInt(btn.dataset.id);
+
+    if (action === 'restore') {
+      const ok = await window.ClawBoard.restoreFromTrash(id);
+      if (ok) {
+        showToast('♻️ 已恢复', 'success');
+        await loadTrashPanel();
+        await loadRecords();
+        await loadStats();
+      } else {
+        showToast('恢复失败', 'error');
+      }
+    } else if (action === 'permanent-delete') {
+      if (!confirm('确定永久删除此记录？此操作不可撤销！')) return;
+      await window.ClawBoard.deleteTrashRecord(id);
+      showToast('已永久删除', 'success');
+      await loadTrashPanel();
     }
   });
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -43,6 +43,7 @@
       </span>
       <button class="icon-btn" id="btnSettings" title="设置">⚙️</button>
       <button class="icon-btn" id="btnPinnedManager" title="置顶管理">📌</button>
+      <button class="icon-btn" id="btnTrash" title="回收站">🗑️</button>
       <button class="icon-btn" id="btnCloudSync" title="云端同步">☁️</button>
     </div>
   </header>
@@ -324,6 +325,34 @@
         <div class="pinned-list" id="pinnedList">
           <div class="loading" id="pinnedLoading">
             <div class="spinner"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 回收站面板 v0.72.0 -->
+  <div class="settings-overlay" id="trashOverlay">
+    <div class="settings-panel" style="width:600px">
+      <div class="settings-header">
+        <h2>🗑️ 回收站</h2>
+        <button class="detail-close" id="btnCloseTrash">×</button>
+      </div>
+      <div class="settings-body">
+        <div class="trash-stats" id="trashStats">
+          <span>回收站中有 <strong id="trashCount">0</strong> 条记录</span>
+          <span class="trash-hint">超过 30 天将自动清理</span>
+        </div>
+        <div class="trash-toolbar">
+          <button class="batch-btn danger" id="btnEmptyTrash" title="清空回收站">🗑️ 清空回收站</button>
+        </div>
+        <div class="trash-list" id="trashList">
+          <div class="loading" id="trashLoading">
+            <div class="spinner"></div>
+          </div>
+          <div class="empty-state" id="trashEmpty" style="display:none">
+            <div class="empty-icon">🗑️</div>
+            <p>回收站为空</p>
           </div>
         </div>
       </div>

--- a/src/renderer/styles_extra.css
+++ b/src/renderer/styles_extra.css
@@ -200,3 +200,16 @@
 .file-preview-toggle:hover{background:var(--accent-bg)}
 .file-preview-content{padding:0.8rem;font-family:'Cascadia Code','Fira Code','Consolas',monospace;font-size:0.82rem;line-height:1.6;white-space:pre-wrap;word-break:break-all;max-height:400px;overflow:auto;background:var(--surface2);color:var(--text);margin:0}
 
+/* v0.72.0: 回收站面板 */
+.trash-stats{display:flex;align-items:center;justify-content:space-between;padding:0.6rem 0.8rem;background:var(--surface);border:1px solid var(--border);border-radius:8px;margin-bottom:0.6rem;font-size:0.85rem;color:var(--text)}
+.trash-hint{font-size:0.75rem;color:var(--muted)}
+.trash-toolbar{display:flex;gap:0.5rem;margin-bottom:0.6rem;justify-content:flex-end}
+.trash-list{flex:1;overflow-y:auto;max-height:55vh}
+.trash-item{display:flex;align-items:center;gap:0.8rem;padding:0.7rem 0.8rem;border:1px solid var(--border);border-radius:8px;margin-bottom:0.4rem;background:var(--surface);transition:all 0.15s}
+.trash-item:hover{background:var(--surface2);border-color:var(--accent)}
+.trash-item-content{flex:1;min-width:0}
+.trash-item-preview{font-size:0.85rem;color:var(--text);line-height:1.5;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.trash-item-meta{display:flex;gap:0.8rem;margin-top:0.3rem;font-size:0.75rem;color:var(--muted)}
+.trash-item-type{padding:0.1rem 0.4rem;border-radius:3px;background:var(--badge-bg);text-transform:uppercase;font-size:0.7rem;letter-spacing:0.5px}
+.trash-item-actions{display:flex;gap:0.4rem;flex-shrink:0}
+


### PR DESCRIPTION
## 回收站功能 #156

### 新增功能
- **软删除机制**：删除记录自动移入回收站，支持恢复和永久删除
- **回收站面板**：header 新增🗑️回收站入口，完整列表展示所有已删除记录
- **30天自动清理**：过期回收站记录定时自动清除，释放存储空间
- **单条操作**：支持单条恢复、单条永久删除
- **一键清空**：支持清空整个回收站

### 技术实现
- SQLite \	rash\ 表存储完整记录元数据（含 original_id、tags、ai_summary 等）
- 软删除：\deleteRecord(id)\ → 复制到 trash + 删除原记录
- 恢复：从 trash 复制回 records + 删除 trash 记录
- 自动清理集成到现有 \startAutoExpiryTimer\ 中，每小时执行一次

### 文件变更
- \src/database.js\: 新增 trash 表、软删除/恢复/清理逻辑
- \src/main.js\: 新增 5 个 IPC handlers，集成自动清理定时器
- \src/preload.js\: 暴露回收站 API
- \src/renderer/app.js\: 回收站面板加载、列表渲染、事件委托
- \src/renderer/index.html\: 回收站面板 HTML 结构
- \src/renderer/styles_extra.css\: 回收站样式