### PR TITLE
fix: pairDevice 未校验重复配对，导致重复设备条目

### DIFF
--- a/src/core/sync/SyncService.js
+++ b/src/core/sync/SyncService.js
@@ -116,6 +116,16 @@ class SyncService extends EventEmitter {
         throw new Error('不能配对同一设备');
       }
 
+      // 检查设备是否已配对，避免重复添加
+      if (this.pairedDevices.has(deviceInfo.deviceId)) {
+        const existingDevice = this.pairedDevices.get(deviceInfo.deviceId);
+        this.log.info(`设备已配对: ${deviceInfo.deviceName}`);
+        return {
+          ...existingDevice,
+          alreadyPaired: true
+        };
+      }
+
       // 添加到配对列表
       this.pairedDevices.set(deviceInfo.deviceId, {
         id: deviceInfo.deviceId,


### PR DESCRIPTION
## 问题描述

修复 #161

当前 SyncService.pairDevice 方法在配对设备时，未检查该设备是否已经存在于 pairedDevices 中，导致同一设备可以多次配对，在配对设备列表中产生重复条目。

## 修复内容

在 \pairDevice\ 方法中，解密配对数据后，增加 \pairedDevices.has(deviceInfo.deviceId)\ 检查：

- 若设备已存在，返回已配对设备信息及 \lreadyPaired: true\ 标记
- 避免重复添加到 pairedDevices 列表

## 测试验证

- 语法检查通过 (\
ode -c\)
- 本地构建正常

## 改动文件

- \src/core/sync/SyncService.js\ (+10 行)