### PR TITLE
fix(security): SQL注入残留修复 + 命令注入防护 + API兼容修复

### DIFF
--- a/src/core/database/Database.js
+++ b/src/core/database/Database.js
@@ -1061,7 +1061,9 @@ class Database {
 
   // 删除标签（从所有记录中移除）
   deleteTag(tag) {
-    const result = this.db.exec(`SELECT id, tags FROM records WHERE tags LIKE ?`, [`%"${tag}"%`]);
+    // 转义 tag 中的特殊字符，防止破坏 LIKE 模式
+    const safeTag = tag.replace(/["'%\\]/g, '\\$&');
+    const result = this.db.exec(`SELECT id, tags FROM records WHERE tags LIKE ?`, [`%"${safeTag}"%`]);
     if (result.length === 0) return 0;
 
     let count = 0;
@@ -1440,9 +1442,13 @@ class Database {
   // v0.71.0: 获取加密统计
   getEncryptionStats() {
     try {
-      const total = this.db.prepare('SELECT COUNT(*) as count FROM records WHERE encrypted = 1').get().count;
-      const byAlgo = this.db.prepare('SELECT encryption_algorithm, COUNT(*) as count FROM records WHERE encrypted = 1 GROUP BY encryption_algorithm').all();
-      return { total, byAlgorithm: byAlgo };
+      const totalResult = this.db.exec('SELECT COUNT(*) as count FROM records WHERE encrypted = 1');
+      const total = totalResult.length ? totalResult[0].values[0][0] : 0;
+      const byAlgoResult = this.db.exec('SELECT encryption_algorithm, COUNT(*) as count FROM records WHERE encrypted = 1 GROUP BY encryption_algorithm');
+      const byAlgorithm = byAlgoResult.length && byAlgoResult[0].values.length
+        ? byAlgoResult[0].values.map(row => ({ encryption_algorithm: row[0], count: row[1] }))
+        : [];
+      return { total, byAlgorithm };
     } catch (e) {
       return { total: 0, byAlgorithm: [] };
     }
@@ -2761,7 +2767,7 @@ class Database {
   }
 
   getStatsByApp(limit) {
-    limit = limit || 10;
+    limit = Math.max(1, Math.min(parseInt(limit) || 10, 1000));
     try {
       const result = this.db.exec(`
       SELECT source_app, COUNT(*) as count
@@ -2769,8 +2775,8 @@ class Database {
       WHERE source_app IS NOT NULL AND source_app != ''
       GROUP BY source_app
       ORDER BY count DESC
-      LIMIT ${limit}
-    `);
+      LIMIT ?
+    `, [limit]);
       if (!result.length || !result[0].values.length) return [];
       return result[0].values.map(row => ({ source_app: row[0], count: row[1] }));
     } catch (e) {
@@ -2780,7 +2786,7 @@ class Database {
   }
 
   getDailyStats(days) {
-    days = days || 30;
+    days = Math.max(1, Math.min(parseInt(days) || 30, 3650));
     try {
       const result = this.db.exec(`
       SELECT
@@ -2791,10 +2797,10 @@ class Database {
         SUM(CASE WHEN type='file' THEN 1 ELSE 0 END) as file_count,
         SUM(CASE WHEN type='image' THEN 1 ELSE 0 END) as image_count
       FROM records
-      WHERE created_at >= DATE('now', '-${days} days')
+      WHERE created_at >= DATE('now', '-' || ? || ' days')
       GROUP BY DATE(created_at)
       ORDER BY date ASC
-    `);
+    `, [String(days)]);
       if (!result.length || !result[0].values.length) return [];
       return result[0].values.map(row => ({
         date: row[0],
@@ -2834,17 +2840,17 @@ class Database {
 
   // v0.62.0: Calendar heatmap data
   getCalendarData(days) {
-    days = days || 365;
+    days = Math.max(1, Math.min(parseInt(days) || 365, 3650));
     try {
       const result = this.db.exec(`
       SELECT 
         DATE(created_at) as date,
         COUNT(*) as count
       FROM records 
-      WHERE created_at >= DATE('now', '-' || ${days} || ' days')
+      WHERE created_at >= DATE('now', '-' || ? || ' days')
       GROUP BY DATE(created_at)
       ORDER BY date ASC
-    `);
+    `, [String(days)]);
       const dataMap = {};
       if (result.length && result[0].values.length) {
         result[0].values.forEach(row => { dataMap[row[0]] = row[1]; });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3429,25 +3429,27 @@ ipcMain.handle("open-in-terminal", async (_, filePath) => {
       return { success: false, error: "路径不存在" };
     }
 
-    // Windows: 使用系统默认终端
-    const { exec } = require("child_process");
+    // Windows: 使用系统默认终端 (spawn 替代 exec 防止命令注入)
+    const { exec, spawn } = require("child_process");
+    // 验证路径合法性：必须存在且为目录
+    if (!fs.existsSync(targetDir) || !fs.statSync(targetDir).isDirectory()) {
+      return { success: false, error: 'Invalid directory path' };
+    }
+    // 路径规范化，消除 ../ 等跳转
+    targetDir = path.resolve(targetDir);
     if (process.platform === "win32") {
       // 优先尝试 Windows Terminal，回退到 cmd
       exec("where wt", (err) => {
         if (!err) {
-          // Windows Terminal 可用
-          exec(`wt -d "${targetDir}"`, { windowsHide: true });
+          spawn('wt', ['-d', targetDir], { windowsHide: true, shell: false, detached: true }).unref();
         } else {
-          // 回退到 cmd
-          exec(`cmd /c start cmd /K "cd /d ${targetDir}"`, {
-            windowsHide: true,
-          });
+          spawn('cmd', ['/c', 'start', 'cmd', '/K', `cd /d ${targetDir}`], { windowsHide: true, shell: false, detached: true }).unref();
         }
       });
     } else if (process.platform === "darwin") {
-      exec(`open -a Terminal "${targetDir}"`);
+      spawn('open', ['-a', 'Terminal', targetDir], { detached: true }).unref();
     } else {
-      exec(`gnome-terminal --working-directory="${targetDir}"`);
+      spawn('gnome-terminal', ['--working-directory', targetDir], { detached: true }).unref();
     }
     return { success: true };
   } catch (err) {
@@ -3579,28 +3581,29 @@ ipcMain.handle("file-open-explorer", async (_, filePath) => {
 ipcMain.handle("file-open-terminal", async (_, filePath) => {
   try {
     const fs = require("fs");
+    const { spawn } = require("child_process");
     const normalizedPath = filePath.trim().replace(/^["']|["']$/g, "");
     const targetDir =
       fs.existsSync(normalizedPath) && fs.statSync(normalizedPath).isFile()
         ? path.dirname(normalizedPath)
         : normalizedPath;
-    if (!fs.existsSync(targetDir)) {
-      return { success: false, error: "路径不存在" };
+    if (!fs.existsSync(targetDir) || !fs.statSync(targetDir).isDirectory()) {
+      return { success: false, error: "路径不存在或不是目录" };
     }
-    const { exec } = require("child_process");
+    // 路径规范化，消除路径跳转
+    const safeDir = path.resolve(targetDir);
     const wtPath = path.join(
       process.env.LOCALAPPDATA,
       "Microsoft",
       "WindowsApps",
       "wt.exe",
     );
-    const cmd = fs.existsSync(wtPath)
-      ? `start "" "$wtPath" -d "$targetDir"`
-      : `start cmd /k "cd /d "$targetDir""`;
-    exec(cmd, (err) => {
-      if (err) log.error("file-open-terminal error:", err);
-    });
-    return { success: true, path: targetDir };
+    if (fs.existsSync(wtPath)) {
+      spawn(wtPath, ['-d', safeDir], { windowsHide: true, shell: false, detached: true }).unref();
+    } else {
+      spawn('cmd', ['/c', 'start', 'cmd', '/k', `cd /d ${safeDir}`], { windowsHide: true, shell: false, detached: true }).unref();
+    }
+    return { success: true, path: safeDir };
   } catch (err) {
     return { success: false, error: err.message };
   }


### PR DESCRIPTION
## 变更内容

### SQL 注入修复 (Database.js)
- **deleteTag**: tag 参数增加特殊字符转义，防止破坏 LIKE 模式
- **getStatsByApp**: limit 改为 parseInt + Math.max/min 范围限制，SQL 使用 LIMIT ? 参数化
- **getDailyStats**: days 参数增加范围验证（1-3650），SQL 使用参数化占位符
- **getCalendarData**: 同上，days 参数化处理

### 命令注入修复 (index.js)
- **open-in-terminal**: exec() -> spawn()，消除 shell 解析风险；新增路径存在性校验 + path.resolve() 规范化
- **file-open-terminal**: 同上，使用 spawn 替代 exec

### Bug 修复
- **getEncryptionStats**: 修复使用了 Node sqlite3 API (prepare().get()/.all()) 的错误，改为 sql.js 兼容的 exec() 方式

Closes #180
