### PR TITLE
fix(trigger): 触发器配置持久化到数据库

### DIFF
--- a/src/core/database/Database.js
+++ b/src/core/database/Database.js
@@ -620,6 +620,27 @@ class Database {
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_rules_priority ON rules(priority DESC)`);
     this.db.run(`CREATE INDEX IF NOT EXISTS idx_rules_enabled ON rules(enabled)`);
 
+    // v0.76.0: 触发器配置持久化
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS triggers (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT DEFAULT '',
+        enabled INTEGER DEFAULT 1,
+        priority INTEGER DEFAULT 50,
+        conditions TEXT DEFAULT '[]',
+        actions TEXT DEFAULT '[]',
+        run_once INTEGER DEFAULT 0,
+        cooldown INTEGER DEFAULT 0,
+        last_run_at TEXT,
+        run_count INTEGER DEFAULT 0,
+        is_default INTEGER DEFAULT 0,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    this.db.run(`CREATE INDEX IF NOT EXISTS idx_triggers_priority ON triggers(priority)`);
+
     this._save();
   }
 
@@ -632,6 +653,86 @@ class Database {
     } catch (err) {
       console.error('数据库保存失败:', err);
     }
+  }
+
+  // ==================== 触发器持久化 ====================
+
+  /**
+   * 获取所有触发器
+   */
+  getAllTriggers() {
+    const result = this.db.exec(`SELECT * FROM triggers ORDER BY priority ASC, created_at ASC`);
+    if (!result.length || !result[0].values.length) return [];
+    return result[0].values.map(row => ({
+      id: row[0],
+      name: row[1],
+      description: row[2],
+      enabled: !!row[3],
+      priority: row[4],
+      conditions: JSON.parse(row[5] || '[]'),
+      actions: JSON.parse(row[6] || '[]'),
+      runOnce: !!row[7],
+      cooldown: row[8],
+      lastRunAt: row[9],
+      runCount: row[10],
+      isDefault: !!row[11],
+      createdAt: row[12],
+      updatedAt: row[13],
+    }));
+  }
+
+  /**
+   * 保存触发器（创建或更新）
+   */
+  saveTrigger(trigger) {
+    const now = new Date().toISOString();
+    const existing = this.db.exec(`SELECT id FROM triggers WHERE id = ?`, [trigger.id]);
+
+    if (existing.length && existing[0].values.length) {
+      // 更新
+      this.db.run(
+        `UPDATE triggers SET name=?, description=?, enabled=?, priority=?, conditions=?, actions=?,
+         run_once=?, cooldown=?, last_run_at=?, run_count=?, is_default=?, updated_at=? WHERE id=?`,
+        [trigger.name, trigger.description || '', trigger.enabled ? 1 : 0, trigger.priority || 50,
+         JSON.stringify(trigger.conditions || []), JSON.stringify(trigger.actions || []),
+         trigger.runOnce ? 1 : 0, trigger.cooldown || 0,
+         trigger.lastRunAt || null, trigger.runCount || 0,
+         trigger.isDefault ? 1 : 0, now, trigger.id]
+      );
+    } else {
+      // 创建
+      this.db.run(
+        `INSERT INTO triggers (id, name, description, enabled, priority, conditions, actions,
+         run_once, cooldown, last_run_at, run_count, is_default, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [trigger.id, trigger.name, trigger.description || '', trigger.enabled ? 1 : 0, trigger.priority || 50,
+         JSON.stringify(trigger.conditions || []), JSON.stringify(trigger.actions || []),
+         trigger.runOnce ? 1 : 0, trigger.cooldown || 0,
+         trigger.lastRunAt || null, trigger.runCount || 0,
+         trigger.isDefault ? 1 : 0, trigger.createdAt || now, now]
+      );
+    }
+    this._save();
+    return trigger;
+  }
+
+  /**
+   * 删除触发器
+   */
+  deleteTrigger(id) {
+    this.db.run(`DELETE FROM triggers WHERE id = ?`, [id]);
+    this._save();
+  }
+
+  /**
+   * 更新触发器运行状态（lastRunAt, runCount）
+   */
+  updateTriggerRunState(id, lastRunAt, runCount) {
+    this.db.run(
+      `UPDATE triggers SET last_run_at=?, run_count=?, updated_at=? WHERE id=?`,
+      [lastRunAt || null, runCount || 0, new Date().toISOString(), id]
+    );
+    // 不调用 _save() 避免高频写盘，状态更新会在下次 saveTrigger 或应用退出时持久化
   }
 
   // 添加记录

--- a/src/utils/TriggerEngine.js
+++ b/src/utils/TriggerEngine.js
@@ -56,8 +56,15 @@ class TriggerEngine {
    */
   _loadTriggers() {
     try {
-      // TODO: 从数据库加载 (当前使用内存存储)
-      log.info(`[Trigger] 已加载 ${this.triggers.size} 个触发器`);
+      if (this.db && typeof this.db.getAllTriggers === 'function') {
+        const saved = this.db.getAllTriggers();
+        if (saved.length > 0) {
+          saved.forEach(trigger => {
+            this.triggers.set(trigger.id, trigger);
+          });
+          log.info(`[Trigger] 从数据库加载了 ${saved.length} 个触发器`);
+        }
+      }
     } catch (err) {
       log.error('[Trigger] 加载失败:', err);
     }
@@ -74,6 +81,7 @@ class TriggerEngine {
         description: '自动去除 URL 中的追踪参数',
         enabled: true,
         priority: 10,
+        isDefault: true,
         conditions: [
           {
             type: 'regex',
@@ -95,6 +103,7 @@ class TriggerEngine {
         description: '自动识别并标记代码片段',
         enabled: true,
         priority: 20,
+        isDefault: true,
         conditions: [
           {
             type: 'regex',
@@ -125,6 +134,7 @@ class TriggerEngine {
         description: '检测到邮箱时提醒加密',
         enabled: true,
         priority: 5,
+        isDefault: true,
         conditions: [
           {
             type: 'regex',
@@ -150,6 +160,7 @@ class TriggerEngine {
         description: '超过1KB的文本建议压缩',
         enabled: true,
         priority: 15,
+        isDefault: true,
         conditions: [
           {
             type: 'maxLength',
@@ -248,6 +259,12 @@ class TriggerEngine {
     };
 
     this.triggers.set(id, trigger);
+
+    // 持久化到数据库
+    if (this.db && typeof this.db.saveTrigger === 'function') {
+      this.db.saveTrigger(trigger);
+    }
+
     log.info(`[Trigger] 创建成功: ${trigger.name} (${id})`);
 
     return trigger;
@@ -271,6 +288,12 @@ class TriggerEngine {
     };
 
     this.triggers.set(id, updated);
+
+    // 持久化到数据库
+    if (this.db && typeof this.db.saveTrigger === 'function') {
+      this.db.saveTrigger(updated);
+    }
+
     log.info(`[Trigger] 更新成功: ${updated.name}`);
 
     return updated;
@@ -286,6 +309,12 @@ class TriggerEngine {
     if (!trigger) return false;
 
     this.triggers.delete(id);
+
+    // 从数据库删除
+    if (this.db && typeof this.db.deleteTrigger === 'function') {
+      this.db.deleteTrigger(id);
+    }
+
     log.info(`[Trigger] 删除成功: ${trigger.name}`);
 
     return true;


### PR DESCRIPTION
## 修复内容

Closes #184

### 问题
TriggerEngine 的触发器配置完全存储在内存 Map 中，_loadTriggers 是空方法。用户通过 IPC 创建/修改/删除的自定义触发器在应用重启后全部丢失。

### 改动

**src/core/database/Database.js** (+101 行)
- 新增 triggers 表，包含完整字段（conditions/actions 以 JSON 存储）
- 实现 getAllTriggers/saveTrigger/deleteTrigger/updateTriggerRunState 四个持久化方法

**src/utils/TriggerEngine.js** (+31 行)
- _loadTriggers 从数据库加载已保存的触发器（替换空 TODO）
- create/update/delete 操作时同步写入数据库
- 4 个默认触发器标记 isDefault: true，用于区分用户自定义触发器

### 测试
- 两个文件 node --check 语法检查通过
- 所有 SQL 使用参数化查询，无注入风险