### PR TITLE
fix: TriggerEngine.testTrigger 重复定义修复 #188

### DIFF
--- a/src/utils/TriggerEngine.js
+++ b/src/utils/TriggerEngine.js
@@ -221,9 +221,13 @@ class TriggerEngine {
       return this.toggleTrigger(id, enabled);
     });
 
-    // 测试触发器 (不实际执行)
+    // 测试触发器（调试模式，模拟执行但不写入数据库）
     ipcMain.handle('test-trigger', async (_, id, testContent) => {
-      return this.testTrigger(id, testContent);
+      try {
+        return { success: true, ...await this.testTrigger(id, testContent) };
+      } catch (err) {
+        return { success: false, error: err.message };
+      }
     });
 
     // 手动运行所有触发器
@@ -767,32 +771,6 @@ class TriggerEngine {
   }
 
   // ==================== 工具方法 ====================
-
-  /**
-   * 测试触发器 (不实际执行)
-   * @param {string} id - 触发器ID
-   * @param {string} testContent - 测试内容
-   * @returns {Object}
-   */
-  testTrigger(id, testContent) {
-    const trigger = this.triggers.get(id);
-    if (!trigger) {
-      return { success: false, error: '触发器不存在' };
-    }
-
-    const conditionResult = this._evaluateConditions(
-      trigger.conditions,
-      testContent,
-      {}
-    );
-
-    return {
-      success: true,
-      triggerName: trigger.name,
-      matched: conditionResult.matched,
-      conditionDetails: conditionResult.details
-    };
-  }
 
   /**
    * 启用/禁用整个引擎


### PR DESCRIPTION
## 修复内容

TriggerEngine.js 中 testTrigger 被定义了两次，同步版本覆盖了异步版本，导致调试功能完全不可用。

### 变更

- 删除重复的同步版本 testTrigger (原第 777 行)，该版本仅评估条件，功能弱于异步版本
- 保留异步版本 async testTrigger (第 392 行)，包含完整的条件评估 + 动作模拟执行 + debugMode 日志
- 更新 IPC handler test-trigger，添加 try-catch 包装统一返回格式

### 影响范围

- 仅修改 src/utils/TriggerEngine.js
- 无破坏性变更，IPC 接口返回值格式兼容
- 81 个测试全部通过

Closes #188