### PR TITLE
fix: playNotificationSound 重复定义导致通知静音 + registerGlobalShortcut 重复调用覆盖用户配置 #192

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -2178,9 +2178,6 @@ app.whenReady().then(async () => {
   // 注册 IPC
   setupIPC();
 
-  // 注册全局快捷键 Ctrl+Shift+V
-  registerGlobalShortcut();
-
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createWindow();
@@ -2690,17 +2687,6 @@ ipcMain.handle("update-shortcut", async (event, shortcut) => {
     return { success: false, message: err.message };
   }
 });
-
-// v0.29.0: 通知与声音功能
-// 播放提示音
-function playNotificationSound() {
-  try {
-    // Electron Notification 使用系统默认音效，silent 参数控制是否静音
-    return { success: true };
-  } catch (e) {
-    log.error("播放提示音失败:", e);
-  }
-}
 
 // 获取通知设置
 ipcMain.handle("get-notification-settings", async () => {


### PR DESCRIPTION
## 关联 Issue

Closes #192

## 修改内容

修复 src/main/index.js 中的两个 bug：

### 1. 删除 playNotificationSound 的重复空定义

文件中有两处 playNotificationSound 定义：
- 第一处（保留）：跨平台声音播放实现，调用 Platform.getNotificationSoundCommand() + exec
- 第二处（已删除）：仅 return { success: true }，无任何实际播放逻辑

第二次定义覆盖了第一次，导致通知声音永远不播放。

### 2. 删除 registerGlobalShortcut() 的重复无参调用

app.whenReady() 中 registerGlobalShortcut 被调用两次：
- 第一次：registerGlobalShortcut(settings) — 使用用户配置
- 第二次：registerGlobalShortcut() — 无参数，使用默认值覆盖

删除第二次调用，保留第一次带用户配置的调用。

## 测试

- 98 个测试全部通过
- 无新增 lint 警告